### PR TITLE
Fixing event copy

### DIFF
--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -344,10 +344,11 @@ class EventData:
     @property
     def elab(self):
         """Return kinetic energy in laboratory frame."""
+        from chromo.util import EventFrame
         kin = self.kin
-        if self.frame == "laboratory":
+        if kin.frame == EventFrame.FIXED_TARGET:
             return self.en
-        return kin.gamma_cm * self.en + kin.betagamma_z_cm * self.pz
+        return kin._gamma_cm * self.en + kin._betagamma_cm * self.pz
 
     @property
     def ekin(self):

--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -345,6 +345,7 @@ class EventData:
     def elab(self):
         """Return kinetic energy in laboratory frame."""
         from chromo.util import EventFrame
+
         kin = self.kin
         if kin.frame == EventFrame.FIXED_TARGET:
             return self.en

--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -122,7 +122,7 @@ class EventData:
         PDG IDs of the particles.
     status: 1D array of int
         Status code of the particles (1 = final).
-    charge: 1D array of double
+    charge: 1D array of float
         Charge in units of elementary charge. Fractional for quarks.
     px: 1D array of double
         X coordinate of momentum in GeV/c.
@@ -177,27 +177,7 @@ class EventData:
 
         This may return a copy if the result cannot represented as a view.
         """
-        return EventData(
-            self.generator,
-            self.kin,
-            self.nevent,
-            self.impact_parameter,
-            self.n_wounded,
-            self.pid[arg],
-            self.status[arg],
-            self.charge[arg],
-            self.px[arg],
-            self.py[arg],
-            self.pz[arg],
-            self.en[arg],
-            self.m[arg],
-            self.vx[arg],
-            self.vy[arg],
-            self.vz[arg],
-            self.vt[arg],
-            select_parents(arg, self.parents),
-            None,
-        )
+        return self._select(arg, True)
 
     def __len__(self):
         """Return number of particles."""
@@ -223,15 +203,39 @@ class EventData:
         bt = dataclasses.astuple(other)
         return all(eq(a, b) for (a, b) in zip(at, bt))
 
+    def __getstate__(self):
+        t = [
+            self.generator,
+            self.kin.copy(),
+            self.nevent,
+            self.impact_parameter,
+            self.n_wounded,
+            self._npart,
+            self.pid.copy(),
+            self.status.copy(),
+            self.charge.copy(),
+            self.px.copy(),
+            self.py.copy(),
+            self.pz.copy(),
+            self.en.copy(),
+            self.m.copy(),
+            self.vx.copy(),
+            self.vy.copy(),
+            self.vz.copy(),
+            self.vt.copy(),
+            self.parents.copy(),
+        ]
+        return t
+
+    def __setstate__(self, state):
+        for f, v in zip(dataclasses.fields(self), state):
+            setattr(self, f.name, v)
+
     def copy(self):
         """
         Return event copy.
         """
-        # this should be implemented with the help of copy
-        copies = []
-        for obj in dataclasses.astuple(self):
-            copies.append(obj.copy() if hasattr(obj, "copy") else obj)
-
+        copies = self.__getstate__()
         return EventData(*copies)
 
     def final_state(self):
@@ -241,7 +245,7 @@ class EventData:
         The final state is generator-specific, but usually contains only
         long-lived particles.
         """
-        return self._fast_selection(self.status == 1)
+        return self._select(self.status == 1, False)
 
     def final_state_charged(self):
         """
@@ -251,7 +255,7 @@ class EventData:
         Additionally, this selects only charged particles which can be
         seen by a tracking detector.
         """
-        return self._fast_selection((self.status == 1) & (self.charge != 0))
+        return self._select((self.status == 1) & (self.charge != 0), False)
 
     def without_parton_shower(self):
         """
@@ -268,15 +272,32 @@ class EventData:
             mask &= apid != pid
         return self[mask]
 
-    def _fast_selection(self, arg):
+    def _select(self, arg, update_parents):
         # This selection is faster than __getitem__, because we skip
         # parent selection, which is just wasting time if we select only
         # final state particles.
-        save = self.parents
-        self.parents = None
-        event = self[arg]
-        self.parents = save
-        return event
+        pid = self.pid[arg]
+        return EventData(
+            self.generator,
+            self.kin,
+            self.nevent,
+            self.impact_parameter,
+            self.n_wounded,
+            len(pid),
+            pid,
+            self.status[arg],
+            self.charge[arg],
+            self.px[arg],
+            self.py[arg],
+            self.pz[arg],
+            self.en[arg],
+            self.m[arg],
+            self.vx[arg],
+            self.vy[arg],
+            self.vz[arg],
+            self.vt[arg],
+            select_parents(arg, self.parents) if update_parents else None,
+        )
 
     @property
     def pt(self):
@@ -602,8 +623,10 @@ class MCRun(ABC):
     def _generate(self):
         """The method to generate a new event.
 
-        Returns:
-            bool : True if event was successfully generated and False otherwise.
+        Returns
+        -------
+        bool
+            True if event was successfully generated and False otherwise.
         """
         pass
 

--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -122,7 +122,7 @@ class EventData:
         PDG IDs of the particles.
     status: 1D array of int
         Status code of the particles (1 = final).
-    charge: 1D array of float
+    charge: 1D array of double
         Charge in units of elementary charge. Fractional for quarks.
     px: 1D array of double
         X coordinate of momentum in GeV/c.
@@ -296,7 +296,7 @@ class EventData:
             self.vz[arg],
             self.vt[arg],
             select_parents(arg, self.parents) if update_parents else None,
-            None
+            None,
         )
 
     @property

--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -210,7 +210,6 @@ class EventData:
             self.nevent,
             self.impact_parameter,
             self.n_wounded,
-            self._npart,
             self.pid.copy(),
             self.status.copy(),
             self.charge.copy(),
@@ -224,6 +223,7 @@ class EventData:
             self.vz.copy(),
             self.vt.copy(),
             self.parents.copy(),
+            self.children.copy() if self.children is not None else None,
         ]
         return t
 
@@ -283,7 +283,6 @@ class EventData:
             self.nevent,
             self.impact_parameter,
             self.n_wounded,
-            len(pid),
             pid,
             self.status[arg],
             self.charge[arg],
@@ -297,6 +296,7 @@ class EventData:
             self.vz[arg],
             self.vt[arg],
             select_parents(arg, self.parents) if update_parents else None,
+            None
         )
 
     @property
@@ -519,7 +519,7 @@ class MCEvent(EventData, ABC):
     # make it so that MCEvent can be saved and is restored as EventData.
     def __getstate__(self):
         # save only EventData sub-state
-        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+        return EventData.__getstate__(self)
 
     def __getnewargs__(self):
         # upon unpickling, create EventData object instead of MCEvent object

--- a/src/chromo/kinematics.py
+++ b/src/chromo/kinematics.py
@@ -37,7 +37,7 @@ __all__ = (
 
 
 @dataclasses.dataclass
-class EventKinematics:
+class EventKinematicsBase:
     """Handles kinematic variables and conversions between reference frames.
 
     There are different ways to specify a particle collision. For instance
@@ -75,10 +75,61 @@ class EventKinematics:
     p1: Union[PDGID, Tuple[int, int]]
     p2: Union[PDGID, Tuple[int, int], CompositeTarget]
     ecm: float  # for ions this is nucleon-nucleon collision system
+    plab: float
+    elab: float
+    ekin: float
     beams: Tuple[np.ndarray, np.ndarray]
     _gamma_cm: float
     _betagamma_cm: float
 
+    def apply_boost(self, event, generator_frame):
+        if generator_frame == self.frame:
+            return
+        CMS = EventFrame.CENTER_OF_MASS
+        FT = EventFrame.FIXED_TARGET
+        if generator_frame == FT and self.frame == CMS:
+            bg = -self._betagamma_cm
+        elif generator_frame == CMS and self.frame == FT:
+            bg = self._betagamma_cm
+        else:
+            raise NotImplementedError(
+                f"Boosts from {generator_frame} to {self.frame} are not yet supported"
+            )
+        g = self._gamma_cm
+        en = g * event.en + bg * event.pz
+        pz = bg * event.en + g * event.pz
+        event.en[:] = en
+        event.pz[:] = pz
+
+    def __eq__(self, other):
+        at = dataclasses.astuple(self)
+        bt = dataclasses.astuple(other)
+
+        def eq(a, b):
+            if isinstance(a, Tuple):
+                return all(eq(ai, bi) for (ai, bi) in zip(a, b))
+            if isinstance(a, np.ndarray):
+                return np.array_equal(a, b)
+            return a == b
+
+        return all(eq(a, b) for (a, b) in zip(at, bt))
+
+    def copy(self):
+        return EventKinematicsBase(
+            self.frame,
+            self.p1,
+            self.p2.copy() if isinstance(self.p2, CompositeTarget) else self.p2,
+            self.ecm,
+            self.plab,
+            self.elab,
+            self.ekin,
+            (self.beams[0].copy(), self.beams[1].copy()),
+            self._gamma_cm,
+            self._betagamma_cm,
+        )
+
+
+class EventKinematics(EventKinematicsBase):
     def __init__(
         self,
         particle1,
@@ -101,115 +152,84 @@ class EventKinematics:
         if particle1 is None or particle2 is None:
             raise ValueError("particle1 and particle2 must be set")
 
-        self.p1 = process_particle(particle1)
-        self.p2 = process_particle(particle2)
+        p1 = process_particle(particle1)
+        p2 = process_particle(particle2)
 
-        if isinstance(self.p1, CompositeTarget):
+        if isinstance(p1, CompositeTarget):
             raise ValueError("Only 2nd particle can be CompositeTarget")
 
-        p2_is_composite = isinstance(self.p2, CompositeTarget)
+        p2_is_composite = isinstance(p2, CompositeTarget)
 
-        m1 = nucleon_mass if is_real_nucleus(self.p1) else mass(self.p1)
-        m2 = nucleon_mass if is_real_nucleus(self.p2) else mass(self.p2)
+        m1 = nucleon_mass if is_real_nucleus(p1) else mass(p1)
+        m2 = nucleon_mass if is_real_nucleus(p2) else mass(p2)
 
-        self.beams = (np.zeros(4), np.zeros(4))
+        beams = (np.zeros(4), np.zeros(4))
 
         # Input specification in center-of-mass frame
         if ecm is not None:
-            self.frame = frame or EventFrame.CENTER_OF_MASS
-            self.ecm = ecm
-            self.elab = ecm2elab(ecm, m1, m2)
-            self.plab = energy2momentum(self.elab, m1)
+            frame = frame or EventFrame.CENTER_OF_MASS
+            ecm = ecm
+            elab = ecm2elab(ecm, m1, m2)
+            plab = energy2momentum(elab, m1)
         # Input specification as 4-vectors
         elif beam is not None:
             if p2_is_composite:
                 raise ValueError("beam cannot be used with CompositeTarget")
-            self.frame = frame or EventFrame.GENERIC
+            frame = frame or EventFrame.GENERIC
             p1, p2 = beam
-            self.beams[0][2] = p1
-            self.beams[1][2] = p2
-            self.beams[0][3] = momentum2energy(p1, m1)
-            self.beams[1][3] = momentum2energy(p2, m2)
-            s = np.sum(self.beams, axis=0)
+            beams[0][2] = p1
+            beams[1][2] = p2
+            beams[0][3] = momentum2energy(p1, m1)
+            beams[1][3] = momentum2energy(p2, m2)
+            s = np.sum(beams, axis=0)
             # We compute ecm with energy2momentum. It is not really energy to momentum,
             # but energy2momentum(x, y) computes x^2 - y^2, which is what we need. Here,
             # I use that px and py are always zero, if we ever change this, many formulas
             # have to change in this class, like all the boosts
-            self.ecm = energy2momentum(s[3], s[2])
-            self.elab = ecm2elab(self.ecm, m1, m2)
-            self.plab = energy2momentum(self.elab, m1)
+            ecm = energy2momentum(s[3], s[2])
+            elab = ecm2elab(ecm, m1, m2)
+            plab = energy2momentum(elab, m1)
         # Input specification in lab frame
         elif elab is not None:
             if not (elab > m1):
                 raise ValueError("projectile energy > projectile mass required")
-            self.frame = frame or EventFrame.FIXED_TARGET
-            self.elab = elab
-            self.plab = energy2momentum(self.elab, m1)
-            self.ecm = elab2ecm(self.elab, m1, m2)
+            frame = frame or EventFrame.FIXED_TARGET
+            elab = elab
+            plab = energy2momentum(elab, m1)
+            ecm = elab2ecm(elab, m1, m2)
         elif ekin is not None:
-            self.frame = frame or EventFrame.FIXED_TARGET
-            self.elab = ekin + m1
-            self.plab = energy2momentum(self.elab, m1)
-            self.ecm = elab2ecm(self.elab, m1, m2)
+            frame = frame or EventFrame.FIXED_TARGET
+            elab = ekin + m1
+            plab = energy2momentum(elab, m1)
+            ecm = elab2ecm(elab, m1, m2)
         elif plab is not None:
-            self.frame = frame or EventFrame.FIXED_TARGET
-            self.plab = plab
-            self.elab = momentum2energy(self.plab, m1)
-            self.ecm = elab2ecm(self.elab, m1, m2)
+            frame = frame or EventFrame.FIXED_TARGET
+            plab = plab
+            elab = momentum2energy(plab, m1)
+            ecm = elab2ecm(elab, m1, m2)
         else:
             assert False  # this should never happen
 
-        self._fill_beams(m1, m2)
+        # fill beams
+        if frame != EventFrame.GENERIC:
+            if frame == EventFrame.CENTER_OF_MASS:
+                s = ecm**2
+                pcm = np.sqrt((s - (m1 + m2) ** 2) * (s - (m1 - m2) ** 2)) / (2 * ecm)
+                beams[0][2] = pcm
+                beams[1][2] = -pcm
+            elif frame == EventFrame.FIXED_TARGET:
+                beams[0][2] = plab
+                beams[1][2] = 0
+            # set energies
+            for b, m in zip(beams, (m1, m2)):
+                b[3] = np.sqrt(m**2 + b[2] ** 2)
 
-        self._gamma_cm = (self.elab + m2) / self.ecm
-        self._betagamma_cm = self.plab / self.ecm
+        _gamma_cm = (elab + m2) / ecm
+        _betagamma_cm = plab / ecm
 
-    def apply_boost(self, event, generator_frame):
-        if generator_frame == self.frame:
-            return
-        CMS = EventFrame.CENTER_OF_MASS
-        FT = EventFrame.FIXED_TARGET
-        if generator_frame == FT and self.frame == CMS:
-            bg = -self._betagamma_cm
-        elif generator_frame == CMS and self.frame == FT:
-            bg = self._betagamma_cm
-        else:
-            raise NotImplementedError(
-                f"Boosts from {generator_frame} to {self.frame} are not yet supported"
-            )
-        g = self._gamma_cm
-        en = g * event.en + bg * event.pz
-        pz = bg * event.en + g * event.pz
-        event.en[:] = en
-        event.pz[:] = pz
-
-    def _fill_beams(self, m1, m2):
-        if self.frame == EventFrame.GENERIC:
-            return  # nothing to do
-        if self.frame == EventFrame.CENTER_OF_MASS:
-            s = self.ecm**2
-            pcm = np.sqrt((s - (m1 + m2) ** 2) * (s - (m1 - m2) ** 2)) / (2 * self.ecm)
-            self.beams[0][2] = pcm
-            self.beams[1][2] = -pcm
-        elif self.frame == EventFrame.FIXED_TARGET:
-            self.beams[0][2] = self.plab
-            self.beams[1][2] = 0
-        # set energies
-        for b, m in zip(self.beams, (m1, m2)):
-            b[3] = np.sqrt(m**2 + b[2] ** 2)
-
-    def __eq__(self, other):
-        at = dataclasses.astuple(self)
-        bt = dataclasses.astuple(other)
-
-        def eq(a, b):
-            if isinstance(a, Tuple):
-                return all(eq(ai, bi) for (ai, bi) in zip(a, b))
-            if isinstance(a, np.ndarray):
-                return np.array_equal(a, b)
-            return a == b
-
-        return all(eq(a, b) for (a, b) in zip(at, bt))
+        super().__init__(
+            frame, p1, p2, ecm, plab, elab, ekin, beams, _gamma_cm, _betagamma_cm
+        )
 
 
 class CenterOfMass(EventKinematics):

--- a/src/chromo/kinematics.py
+++ b/src/chromo/kinematics.py
@@ -170,6 +170,7 @@ class EventKinematics(EventKinematicsBase):
             frame = frame or EventFrame.CENTER_OF_MASS
             ecm = ecm
             elab = ecm2elab(ecm, m1, m2)
+            ekin = elab - m1
             plab = energy2momentum(elab, m1)
         # Input specification as 4-vectors
         elif beam is not None:
@@ -188,6 +189,7 @@ class EventKinematics(EventKinematicsBase):
             # have to change in this class, like all the boosts
             ecm = energy2momentum(s[3], s[2])
             elab = ecm2elab(ecm, m1, m2)
+            ekin = elab - m1
             plab = energy2momentum(elab, m1)
         # Input specification in lab frame
         elif elab is not None:
@@ -195,6 +197,7 @@ class EventKinematics(EventKinematicsBase):
                 raise ValueError("projectile energy > projectile mass required")
             frame = frame or EventFrame.FIXED_TARGET
             elab = elab
+            ekin = elab - m1
             plab = energy2momentum(elab, m1)
             ecm = elab2ecm(elab, m1, m2)
         elif ekin is not None:
@@ -206,6 +209,7 @@ class EventKinematics(EventKinematicsBase):
             frame = frame or EventFrame.FIXED_TARGET
             plab = plab
             elab = momentum2energy(plab, m1)
+            ekin = elab - m1
             ecm = elab2ecm(elab, m1, m2)
         else:
             assert False  # this should never happen

--- a/src/chromo/kinematics.py
+++ b/src/chromo/kinematics.py
@@ -152,16 +152,16 @@ class EventKinematics(EventKinematicsBase):
         if particle1 is None or particle2 is None:
             raise ValueError("particle1 and particle2 must be set")
 
-        p1 = process_particle(particle1)
-        p2 = process_particle(particle2)
+        part1 = process_particle(particle1)
+        part2 = process_particle(particle2)
 
-        if isinstance(p1, CompositeTarget):
+        if isinstance(part1, CompositeTarget):
             raise ValueError("Only 2nd particle can be CompositeTarget")
 
-        p2_is_composite = isinstance(p2, CompositeTarget)
+        p2_is_composite = isinstance(part2, CompositeTarget)
 
-        m1 = nucleon_mass if is_real_nucleus(p1) else mass(p1)
-        m2 = nucleon_mass if is_real_nucleus(p2) else mass(p2)
+        m1 = nucleon_mass if is_real_nucleus(part1) else mass(part1)
+        m2 = nucleon_mass if is_real_nucleus(part2) else mass(part2)
 
         beams = (np.zeros(4), np.zeros(4))
 
@@ -228,7 +228,7 @@ class EventKinematics(EventKinematicsBase):
         _betagamma_cm = plab / ecm
 
         super().__init__(
-            frame, p1, p2, ecm, plab, elab, ekin, beams, _gamma_cm, _betagamma_cm
+            frame, part1, part2, ecm, plab, elab, ekin, beams, _gamma_cm, _betagamma_cm
         )
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,39 @@
-from chromo.common import CrossSectionData
+from chromo.common import CrossSectionData, EventData, MCEvent
+from chromo.kinematics import CenterOfMass
 import numpy as np
 import dataclasses
+import pickle
+from types import SimpleNamespace
+import pytest
+from numpy.testing import assert_equal
+
+
+@pytest.fixture
+def evt():
+    i = np.array([1, 2, 3])
+    f = np.array([1.1, 2.2, 3.3])
+    p = np.array([[1, -1], [2, -1], [2, 3]])
+    return EventData(
+        "generator",
+        CenterOfMass(10, "p", "p"),
+        1,
+        0.5,
+        (1, 1),
+        i,
+        i,
+        f,
+        f,
+        f,
+        f,
+        f,
+        f,
+        f,
+        f,
+        f,
+        f,
+        p,
+        p,
+    )
 
 
 def test_cross_section_empty():
@@ -26,3 +59,60 @@ def test_cross_section_eq():
     assert cx1 == cx2
     cx2.inelastic = 10
     assert cx1 != cx2
+
+
+def test_EventData_copy_and_pickle(evt):
+    evt2 = evt.copy()
+    assert evt2 == evt
+
+    s = pickle.dumps(evt)
+    evt3 = pickle.loads(s)
+
+    assert evt3 == evt
+
+
+class DummyEvent(MCEvent):
+    def __init__(self):
+        hepevt = SimpleNamespace(
+            nevhep=1,
+            nhep=2,
+            idhep=np.ones(3, dtype=np.int32),
+            isthep=np.ones(3, dtype=np.int32),
+            phep=np.ones((3, 5), dtype=np.double).T,
+            vhep=np.ones((3, 4), np.double).T,
+            jmohep=np.ones((3, 2), np.int32),
+            jdahep=np.ones((3, 2), np.int32),
+        )
+
+        lib = SimpleNamespace(hepevt=hepevt)
+
+        generator = SimpleNamespace(
+            _lib=lib,
+            name="foo",
+            version="bar",
+            kinematics=CenterOfMass(10, "p", "p"),
+        )
+
+        super().__init__(generator)
+
+    def _charge_init(self, npart):
+        return np.zeros(npart)
+
+
+def test_MCEvent_copy():
+    evt = DummyEvent()
+    evt2 = evt.copy()
+    assert evt2 == evt
+
+    s = pickle.dumps(evt)
+    evt3 = pickle.loads(s)
+
+    assert evt3 == evt
+
+
+def test_EventData_select(evt):
+    x = evt[1]
+    assert x.pid == evt.pid[1]
+
+    x = evt[[True, False, True]]
+    assert_equal(x.pid, [1, 3])

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -1,4 +1,5 @@
 from chromo.kinematics import (
+    CenterOfMass,
     FixedTarget,
     TotalEnergy,
     KinEnergy,
@@ -81,3 +82,9 @@ def test_fixed_target_bad_input():
 
     with pytest.raises(ValueError):
         FixedTarget(100 * GeV, t, "p")
+
+
+def test_copy():
+    a = CenterOfMass(10, "p", "p")
+    b = a.copy()
+    assert a == b


### PR DESCRIPTION
This fixes issues I saw when developing something else with EventData.copy.
- EventData.copy did not copy the kinematics object, it was shared
- EventKinematics object got changed into a tuple by the copy
- I added some tests of copying and pickling of EventData and MCEvent, to ensure that the implementation works

I discovered that dataclasses.astuple works recursively if the dataclass also holds other dataclasses. This caused the second issue.

EventKinematics is now a thin class with just an init over EventKinematicsBase. This was necessary to make copies. I need to be able to call the raw init of the data holder (EventKinematicsBase), but we also want to customize the init. Since Python does not have overloads, I use this solution.

Other changes:
- EventData._fast_selection was replaced with EventData._select, to simplify the code
- I added a test of `EventData.__getitem__` which calls EventData._select