### PR TITLE
Epos random dummy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,8 @@ set(rangen_source ${fortran_dir}/rangen.fpp ${fortran_dir}/rangen.c ${fortran_di
 ### eposlhc
 file(GLOB eposlhc_sources ${fortran_dir}/epos/sources/*.f)
 list(FILTER eposlhc_sources EXCLUDE REGEX epos_example\.f)
-
+list(FILTER eposlhc_sources EXCLUDE REGEX epos-random\.f)
+list(APPEND eposlhc_sources ${fortran_dir}/epos/epos-random-dummy.f)
 
 f2py_add_module(_eposlhc
   FUNCTIONS

--- a/model.cfg
+++ b/model.cfg
@@ -1,18 +1,18 @@
 eposlhc
-sib21
-sib23
-sib23d
-sib23c01
-qgs01
-qgsII03
-qgsII04
-pythia6
-sophia
-dpmjet306
-phojet112
-phojet191
-phojet193
-dpmjetIII191
-dpmjetIII193
-urqmd34
-pythia8
+# sib21
+# sib23
+# sib23d
+# sib23c01
+# qgs01
+# qgsII03
+# qgsII04
+# pythia6
+# sophia
+# dpmjet306
+# phojet112
+# phojet191
+# phojet193
+# dpmjetIII191
+# dpmjetIII193
+# urqmd34
+# pythia8

--- a/model.cfg
+++ b/model.cfg
@@ -1,18 +1,18 @@
 eposlhc
-# sib21
-# sib23
-# sib23d
-# sib23c01
-# qgs01
-# qgsII03
-# qgsII04
-# pythia6
-# sophia
-# dpmjet306
-# phojet112
-# phojet191
-# phojet193
-# dpmjetIII191
-# dpmjetIII193
-# urqmd34
-# pythia8
+sib21
+sib23
+sib23d
+sib23c01
+qgs01
+qgsII03
+qgsII04
+pythia6
+sophia
+dpmjet306
+phojet112
+phojet191
+phojet193
+dpmjetIII191
+dpmjetIII193
+urqmd34
+pythia8

--- a/src/fortran/epos/epos-random-dummy.f
+++ b/src/fortran/epos/epos-random-dummy.f
@@ -1,0 +1,49 @@
+c=======================================================================
+c     Below: Dummy implementations of PRNG initialization functions
+c     used by EPOS. We use the Numpy PRNG so these functions are
+c     replaced with dummies that do nothing.
+c=======================================================================
+
+c=======================================================================
+      subroutine rmmaqd( iseed, iseq, chopt )
+c-----------------------------------------------------------------------
+      implicit none
+      integer          iseed(3), iseq
+      character        chopt*(*), cchopt*12
+      end
+
+c=======================================================================
+      subroutine ranfgt(seed)
+c-----------------------------------------------------------------------
+      implicit none
+      double precision seed
+      end
+
+c=======================================================================
+      subroutine ranfini(seed,iseq,iqq)
+c-----------------------------------------------------------------------
+      implicit none
+      double precision seed
+      integer iseq, iqq
+      end
+
+c=======================================================================
+      subroutine ranfcv(seed)
+c-----------------------------------------------------------------------
+      implicit none
+      double precision seed
+      end
+
+c=======================================================================
+      subroutine ranflim(seed)
+c-----------------------------------------------------------------------
+      implicit none
+      double precision seed
+      end
+
+c=======================================================================
+      subroutine ranfst(seed)
+c-----------------------------------------------------------------------
+      implicit none
+      double precision seed
+      end

--- a/src/fortran/epos/sources/epos-random.f
+++ b/src/fortran/epos/sources/epos-random.f
@@ -33,7 +33,6 @@ c-----------------------------------------------------------------------
       if(irandm.eq.1)write(ifch,*)'cxrangen()= ',cxrangen
       return
       end
-#ifndef CHROMO
 c Random number generator from CORSIKA *********************************
 C=======================================================================
       DOUBLE PRECISION FUNCTION DRANF(dummy)
@@ -391,46 +390,3 @@ C  COMPLETE INITIALIZATION BY SKIPPING (NTOT2*MODCNS+NTOT) RANDOMNUMBERS
       ENDIF
       RETURN
       END
-#else
-C     Dummy implementations of PRNG initialization functions.
-C     We use the Numpy RNG so these functions are replaced with
-C     dummies that do nothing. dranf is implemented in rangen.fpp.
-      SUBROUTINE RMMAQD( ISEED, ISEQ, CHOPT )
-      implicit none
-      integer          ISEED(3), ISEQ
-      character        CHOPT*(*), CCHOPT*12
-      return
-      end
-
-      SUBROUTINE ranfgt(seed)
-      implicit none
-      double precision seed
-      return
-      end
-
-      SUBROUTINE ranfini(seed,iseq,iqq)
-      implicit none
-      double precision seed
-      integer iseq, iqq
-      return
-      end
-
-      subroutine ranfcv(seed)
-      implicit none
-      double precision seed
-      return
-      end
-
-      subroutine ranflim(seed)
-      implicit none
-      double precision seed
-      return
-      end
-
-      subroutine ranfst(seed)
-      implicit none
-      double precision seed
-      return
-      end
-
-#endif

--- a/src/fortran/rangen.fpp
+++ b/src/fortran/rangen.fpp
@@ -12,6 +12,27 @@ c-----------------------------------------------------------------------
       end
 
 c=======================================================================
+      function rangen()
+c-----------------------------------------------------------------------
+c  used by EPOS
+c-----------------------------------------------------------------------
+      double precision rval
+      call npyrng(rval)
+ 1    rangen=sngl(rval)
+      if(rangen.le.0.)goto 1
+      if(rangen.ge.1.)goto 1
+      end
+
+c=======================================================================
+      function drangen(dummy)
+c-----------------------------------------------------------------------
+c  used by EPOS
+c-----------------------------------------------------------------------
+      double precision drangen, dummy
+      call npyrng(drangen)
+      end
+
+c=======================================================================
       double precision function simrnd()
 c-----------------------------------------------------------------------
 c  alternative interface to npyrng
@@ -20,12 +41,13 @@ c-----------------------------------------------------------------------
       end
 
 c=======================================================================
-      double precision function gasdev( dummy )
+      function gasdev( dummy )
 c-----------------------------------------------------------------------
 c  used by SIBYLL-2.3x
 c-----------------------------------------------------------------------
       implicit none
       external npygas
+      double precision gasdev
       integer dummy
       integer*8 bitgen
       common /npy/bitgen
@@ -33,32 +55,19 @@ c-----------------------------------------------------------------------
       end
 
 c=======================================================================
-      real function spgasdev( dummy )
+      function spgasdev( dummy )
 c-----------------------------------------------------------------------
 c  used by SIBYLL-2.1
 c-----------------------------------------------------------------------
       implicit none
       external npygas
+      real spgasdev
       integer dummy
       integer*8 bitgen
       common /npy/bitgen
       double precision rval
       call npygas(rval, bitgen)
-      spgasdev = real(rval)
-      end
-
-c=======================================================================
-      subroutine rmmard( rvec,lenv,iseq )
-c-----------------------------------------------------------------------
-c  used by epos
-c-----------------------------------------------------------------------
-      implicit none
-      double precision rvec(*), rval
-      integer iseq,lenv,ivec
-      do ivec = 1, lenv
-        call npyrng(rval)
-        rvec(ivec) = rval
-      enddo
+      spgasdev = sngl(rval)
       end
 
 c=======================================================================
@@ -81,32 +90,42 @@ c-----------------------------------------------------------------------
       end
 
 c=======================================================================
-      double precision function dranf(dummy)
+      subroutine rmmard( rvec,lenv,iseq )
 c-----------------------------------------------------------------------
 c  used by epos
 c-----------------------------------------------------------------------
       implicit none
-      double precision dummy
+      double precision rvec(*)
+      integer lenv,iseq
+      call rm48(rvec,lenv)
+      end
+
+c=======================================================================
+      function dranf(dummy)
+c-----------------------------------------------------------------------
+c  used by epos
+c-----------------------------------------------------------------------
+      implicit none
+      double precision dranf,dummy
       call npyrng(dranf)
       end
 
 c=======================================================================
 c  sibyll random generator
 c-----------------------------------------------------------------------
-#ifdef SIBYLL_21
-      real function s_rndm(dummy)
-#else
-      double precision function s_rndm(dummy)
-#endif 
+      function s_rndm(dummy)
 c-----------------------------------------------------------------------
       implicit none
       integer dummy
-      double precision simrnd
 #ifdef SIBYLL_21
-555   s_rndm = real(simrnd())
-      if ((s_rndm.le.0e0).or.(s_rndm.ge.1e0)) goto 555     
+      real s_rndm
+      double precision rval
+555   call npyrng(rval)
+      if ((rval.le.0e0).or.(rval.ge.1e0)) goto 555
+      s_rndm = sngl(rval)
 #else
-      s_rndm = simrnd()
+      double precision s_rndm
+      call npyrng(s_rndm)
 #endif
       end
 


### PR DESCRIPTION
Minor change.

After talking to Tanguy, I agree that it is better to reduce ifdefs in the original fortran codes. So instead of using ifdef CHROMO in epos-random.f, I made a dummy epos-random-dummy.f with the blank initialization routines and implemented the functions rangen and drangen that produce random numbers in rangen.fpp.