### PR TITLE
Allow to include vertex info via format option system

### DIFF
--- a/src/chromo/cli.py
+++ b/src/chromo/cli.py
@@ -65,8 +65,9 @@ VALID_MODELS = ", ".join(sorted(VALID_MODELS))
 
 FORMATS = {
     "hepmc": writer.Hepmc,
-    "hepmcgz": writer.Hepmc,
+    "hepmc:gz": writer.Hepmc,
     "root": writer.Root,
+    "root:vertex": lambda *args: writer.Root(*args, write_vertices=True),
     "svg": writer.Svg,
     "null": writer.Null,
     # "lhe",
@@ -76,9 +77,10 @@ VALID_FORMATS = f"{', '.join(FORMATS)}"
 
 
 def extension(format):
-    if format.endswith("gz"):
-        return format[:-2] + ".gz"
-    return format
+    extension, *options = format.split(":")
+    if "gz" in options:
+        return f"{extension}.gz"
+    return extension
 
 
 def process_particle(x):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,20 +262,23 @@ def test_format_1():
     )
 
 
-@pytest.mark.parametrize("format", ("hepmc", "hepmcgz", "root"))
+@pytest.mark.parametrize("format", ("hepmc", "hepmc:gz", "root", "root:vertex"))
 @pytest.mark.parametrize("model", ("EPOS-LHC", "SIBYLL-2.1", "Pythia-6.4"))
 def test_format_2(format, model):
-    ext = format
-    if ext.endswith("gz"):
-        ext = ext[:-2] + ".gz"
+    ext, *options = format.split(":")
+    if "gz" in options:
+        ext += ".gz"
 
     pyname = {"EPOS-LHC": "eposlhc", "SIBYLL-2.1": "sibyll21", "Pythia-6.4": "pythia6"}[
         model
     ]
 
+    # seeds must be unique to not have clashing file names
+    seed = "888" if "vertex" in options else "8"
+
     run(
         "-s",
-        "8",
+        seed,
         "-S",
         "100",
         "-o",
@@ -283,7 +286,7 @@ def test_format_2(format, model):
         "-m",
         model,
         stdout=f"Format[ \t]*{format}",
-        file=f"chromo_{pyname}_8_2212_2212_100.{ext}",
+        file=f"chromo_{pyname}_{seed}_2212_2212_100.{ext}",
     )
 
 


### PR DESCRIPTION
The Root writer does not write the vertex info by default to save disk space. It was foreseen to optionally save the vertex info, but a configuration option was missing.

I now added a configuration system for the output format. You can now provide options to the format via colon, e.g. `format:option1:option2[...]`. Currently, there are two formats which accept options.
* `hepmc` accepts `gz`, e.g. you can pass `hepmc` and `hepmc:gz`
* `root` accepts `vertex`, e.g. you can pass `root` and `root:vertex`