### PR TITLE
Fix rangen for EPOS

### DIFF
--- a/src/fortran/rangen.fpp
+++ b/src/fortran/rangen.fpp
@@ -17,14 +17,13 @@ c-----------------------------------------------------------------------
 c  used by EPOS
 c-----------------------------------------------------------------------
       double precision rval
-      call npyrng(rval)
- 1    rangen=sngl(rval)
-      if(rangen.le.0.)goto 1
-      if(rangen.ge.1.)goto 1
+ 20   call npyrng(rval)
+      if(rval.le.0.or.rval.ge.1) goto 20
+      rangen=sngl(rval)
       end
 
 c=======================================================================
-      function drangen(dummy)
+      function drangen( dummy )
 c-----------------------------------------------------------------------
 c  used by EPOS
 c-----------------------------------------------------------------------


### PR DESCRIPTION
This is a hotfix for a mistake I introduced when I changed the random number generation. Without this fix, EPOS eventually runs into an infinite loop at some point after X events generated.

Since this is a simple hotfix, I will merge this myself.