### PR TITLE
Do not append file extension if user provides filename

### DIFF
--- a/src/chromo/cli.py
+++ b/src/chromo/cli.py
@@ -325,6 +325,8 @@ def main():
     else:  # cms mode
         evt_kin = CenterOfMass(args.sqrts, args.projectile_id, args.target_id)
 
+    print("DEBUG", args.out)
+
     task_id = None
     try:
         model = args.model(evt_kin, seed=args.seed)

--- a/src/chromo/cli.py
+++ b/src/chromo/cli.py
@@ -325,8 +325,6 @@ def main():
     else:  # cms mode
         evt_kin = CenterOfMass(args.sqrts, args.projectile_id, args.target_id)
 
-    print("DEBUG", args.out)
-
     task_id = None
     try:
         model = args.model(evt_kin, seed=args.seed)

--- a/src/chromo/cli.py
+++ b/src/chromo/cli.py
@@ -272,12 +272,12 @@ def parse_arguments():
             fn = f"chromo_{mn}_{args.seed}_{int(pid1)}_{int(pid2)}_{en}.{ext}"
             odir = os.environ.get("CRMC_OUT", ".")
             args.out = Path(odir) / fn
-
-        if not args.out.suffixes[-2:]:
-            ext = "." + args.output
-            if ext.endswith("gz"):
-                ext = ext[:-2] + ".gz"
-            args.out = Path(args.out).with_suffix(ext)
+            # append extension
+            if not args.out.suffixes[-2:]:
+                ext = "." + args.output
+                if ext.endswith("gz"):
+                    ext = ext[:-2] + ".gz"
+                args.out = Path(args.out).with_suffix(ext)
 
     if args.output not in FORMATS:
         raise SystemExit(f"Error: unknown format {args.output} ({VALID_FORMATS})")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,3 +307,16 @@ def test_format_3():
         stdout="Format[ \t]*svg",
         file="chromo_eposlhc_9_2212_2212_100_000.svg",
     )
+
+
+def test_filename_option():
+    run(
+        "-s",
+        "10",
+        "-S",
+        "100",
+        "-f",
+        "foobar",
+        file="foobar",
+        checks=(),
+    )


### PR DESCRIPTION
Hot-fix for CLI: If the user provides the `-f` option, do not append a filename extension.

This is a hot-fix for a bug in code that I wrote, so I will merge the patch myself.