### PR TITLE
Hot-fix for broken second parent in Pythia8 parents

### DIFF
--- a/src/cpp/_pythia8.cpp
+++ b/src/cpp/_pythia8.cpp
@@ -88,7 +88,7 @@ py::array_t<int> event_array_parents(Event &event)
     auto ptr2 = &private_access::member<Particle_mother2Save>(event[1]);
     int number = event.size() - 1;
     int shape[2] = {number, 2};
-    int strides[2] = {sizeof(Particle), static_cast<int>(ptr2 - ptr1)};
+    int strides[2] = {sizeof(Particle), sizeof(int)};
     return py::array_t<int>(shape, strides, ptr1);
 }
 

--- a/src/cpp/_pythia8.cpp
+++ b/src/cpp/_pythia8.cpp
@@ -99,7 +99,7 @@ py::array_t<int> event_array_children(Event &event)
     auto ptr2 = &private_access::member<Particle_daughter2Save>(event[1]);
     int number = event.size() - 1;
     int shape[2] = {number, 2};
-    int strides[2] = {sizeof(Particle), static_cast<int>(ptr2 - ptr1)};
+    int strides[2] = {sizeof(Particle), sizeof(int)};
     return py::array_t<int>(shape, strides, ptr1);
 }
 

--- a/tests/test_pythia8.py
+++ b/tests/test_pythia8.py
@@ -84,7 +84,8 @@ def test_children(event):
 
 
 def test_parents(event):
-    assert event.parents.shape == (len(event), 2)
+    n = len(event)
+    assert event.parents.shape == (n, 2)
     # same particles have no parents
     assert sum(x[0] == 0 and x[1] == 0 for x in event.parents) > 0
 
@@ -93,6 +94,8 @@ def test_parents(event):
 
     # some particles have multiple parents
     assert sum(x[0] > 0 and x[1] > 0 for x in event.parents) > 0
+
+    assert sum(x[1] >= 0 and x[1] < len(event) for x in event.parents) == n
 
 
 @pytest.mark.skip(reason="Simulating nuclei in Pythia8 is very time-consuming")


### PR DESCRIPTION
This is a hot-fix for my recent change to the Pythia8 event view. Undetected by our tests, the second parent index was pointing to the wrong memory position, so that the second parent index was garbage. I added a new test to which should catch this in the future.

This is another hot-fix for a bug, so I will merge this myself.