### PR TITLE
Fix for seed issue in Pythia8; return correct seed when seed is None

### DIFF
--- a/src/chromo/common.py
+++ b/src/chromo/common.py
@@ -554,7 +554,6 @@ class MCRun(ABC):
         assert hasattr(self, "_frame")
         self._lib = importlib.import_module(f"chromo.models.{self._library_name}")
 
-        self._seed = seed
         self._rng = np.random.default_rng(seed)
         if hasattr(self._lib, "npy"):
             self._lib.npy.bitgen = self._rng.bit_generator.ctypes.bit_generator.value
@@ -589,7 +588,9 @@ class MCRun(ABC):
 
     @property
     def seed(self):
-        return self._seed
+        # This is using private interface to get the seed. This may be brittle.
+        # I did not find a way to get the seed using the public API.
+        return self._rng._bit_generator._seed_seq.entropy
 
     @classproperty
     def name(cls):

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -126,13 +126,11 @@ class Pythia8(MCRun):
 
         # TODO use numpy PRNG instead of Pythia's
         config += [
-            # use our random seed
-            "Random:setSeed = on",
-            f"Random:seed = {self._seed}",
-            # use center-of-mass frame
-            "Beams:frameType = 1",
-            # reduce verbosity
-            "Print:quiet = on",
+            "Random:setSeed = on",  # Use our random seed
+            # Pythia accepts only seeds smaller than int(2.14e9)
+            f"Random:seed = {self.seed % int(2.14e9)}",
+            "Beams:frameType = 1",  # Use center-of-mass frame
+            "Print:quiet = on",  # Reduce verbosity
             "Next:numberCount = 0",  # do not print progress
         ]
 

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -126,12 +126,17 @@ class Pythia8(MCRun):
 
         # TODO use numpy PRNG instead of Pythia's
         config += [
-            "Random:setSeed = on",  # Use our random seed
-            # Pythia accepts only seeds smaller than int(2.14e9)
-            f"Random:seed = {self.seed % int(2.14e9)}",
-            "Beams:frameType = 1",  # Use center-of-mass frame
-            "Print:quiet = on",  # Reduce verbosity
-            "Next:numberCount = 0",  # do not print progress
+            # Use our random seed
+            "Random:setSeed = on",
+            # Pythia's RANMAR PRNG accepts only seeds smaller than 900_000_000.
+            # This may change in the future if they switch to a different PRNG.
+            f"Random:seed = {self.seed % 900_000_000}",
+            # Use center-of-mass frame
+            "Beams:frameType = 1",
+            # Reduce verbosity
+            "Print:quiet = on",
+            # do not print progress
+            "Next:numberCount = 0",
         ]
 
         if (kin.p1.A or 0) > 1 or (kin.p2.A or 1) > 1:

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -126,14 +126,14 @@ class Pythia8(MCRun):
 
         # TODO use numpy PRNG instead of Pythia's
         config += [
-            # Use our random seed
+            # use our random seed
             "Random:setSeed = on",
-            # Pythia's RANMAR PRNG accepts only seeds smaller than 900_000_000.
-            # This may change in the future if they switch to a different PRNG.
+            # Pythia's RANMAR PRNG accepts only seeds smaller than 900_000_000,
+            # this may change in the future if they switch to a different PRNG
             f"Random:seed = {self.seed % 900_000_000}",
-            # Use center-of-mass frame
+            # use center-of-mass frame
             "Beams:frameType = 1",
-            # Reduce verbosity
+            # reduce verbosity
             "Print:quiet = on",
             # do not print progress
             "Next:numberCount = 0",

--- a/tests/test_pythia8.py
+++ b/tests/test_pythia8.py
@@ -137,9 +137,19 @@ def test_event(event):
     assert_equal(event.pid[:2], (2212, 2212))
 
 
-def test_pythia_elastic():
+def test_elastic():
     evt_kin = CenterOfMass(10 * GeV, "p", "p")
     m = Pythia8(evt_kin, seed=1, config=["SoftQCD:elastic=on"])
     for event in m(10):
         assert len(event) == 4
         assert_equal(event.pid, [2212] * 4)
+
+
+@pytest.mark.parametrize("seed", (None, 0, 1, int(1e10)))
+def test_seed(seed):
+    evt_kin = CenterOfMass(10 * GeV, "p", "p")
+    m = Pythia8(evt_kin, seed=seed)
+    if seed is None:
+        assert m.seed >= 0
+    else:
+        assert m.seed == seed


### PR DESCRIPTION
Since I changed the PRNG, the correct way to use a random seed is to pass seed=None to `MCRun.__init__`. However, this introduced a bug for Pythia8, which is the only generator that is currently not using the Numpy PRNG. `None` in this case was directly forward to the Pythia config, which failed since it cannot handle that value. This patch fixes the issue. Pythia8 now gets the seed which Numpy generates when `seed=None` is used.

I also fixed a related bug, which affects all models. If `seed=None` was used, `MCRun.seed` also incorrectly returned `None`. This is not intended behavior, we want to know the seed that was actually used even if we do not specify it, so that we can reproduce the output of the generator. I changed the seed property in `MCRun` now so that the actual seed is returned that Numpy generated when `seed=None` is used.