### PR TITLE
Fix workflow file 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
 
   wheels:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.base_ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     name: ${{ matrix.py }} ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -163,6 +163,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Dump GitHub context
+        run: echo '${{ toJSON(github) }}'
+
       - uses: actions/setup-python@v4
         name: Install Python
         with:
@@ -183,7 +186,7 @@ jobs:
     name: Upload to PyPI
     needs: [wheels, sdist]
     runs-on: ubuntu-latest
-    if: ${{ github.event.base_ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Download files in artifact to "dist/" directory
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This is a second trial to launch PyPI. There is a problem with conditions. It seems that `github.event.base_ref` is null. At least this is what it shows when the workflow was launched on a fork. On my test repository `github.event.base_ref` has correct value. I tested conditions on a fork of chromo and made a release. It worked. I hope this time it should work.