### PR TITLE
Lower ecm_min for EPOS-LHC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "cmake",
     "numpy==1.26.2",
-    "charset_normalizer"
+    "charset_normalizer",
 ]
 #build-backend = "setuptools.build_meta"
 
@@ -19,10 +19,7 @@ ignore_missing_imports = true
 minversion = "6.0"
 addopts = "-q -ra --ff -n auto"
 testpaths = ["tests"]
-filterwarnings = [
-    "error::numpy.VisibleDeprecationWarning",
-    "error::DeprecationWarning",
-]
+filterwarnings = ["error::FutureWarning", "error::DeprecationWarning"]
 
 [tool.cibuildwheel]
 # update skip when numpy wheels become available

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    numpy >= 1.23
+    numpy >= 1.23, < 2
     scipy
     particle
     rich

--- a/src/chromo/models/epos.py
+++ b/src/chromo/models/epos.py
@@ -1,5 +1,5 @@
 import numpy as np
-from chromo.kinematics import EventFrame
+from chromo.kinematics import EventFrame, GeV
 from chromo.common import MCEvent, MCRun, CrossSectionData
 from chromo.util import (
     _cached_data_dir,
@@ -181,6 +181,7 @@ class EposLHC(MCRun):
         "https://github.com/impy-project/chromo"
         + "/releases/download/zipped_data_v1.0/epos_v001.zip"
     )
+    _ecm_min = 6 * GeV
 
     def __init__(self, evt_kin, *, seed=None):
         import chromo


### PR DESCRIPTION
As user Ashley pointed out, EPOS-LHC accepts sqrt(s) values down to 6 GeV, while we impose the limit at 10 GeV. This patch lowers our threshold to 6 GeV. I tried lowering it more, but then you get error messages from EPOS-LHC.