### PR TITLE
Try to fix wounded particle missing issue in Sibyll

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ common_syms = ['chromo_openlogfile','chromo_closelogfile','npyrng']
 sibyll_syms_base  = [
   'sibyll','sibyll_ini','sib_sigma_hp','sib_sigma_hair','sib_sigma_hnuc',
   'int_nuc','decsib','decpar','sibini','sibhep','sib_list',
-  'isib_pid2pdg','isib_pdg2pid','pdg_ini', 'sibnuc', 'sigma_nuc_nuc']
+  'isib_pid2pdg','isib_pdg2pid','pdg_ini', 'sibnuc', 'sigma_nuc_nuc', 'int_h_nuc']
 qgs_syms_base     = ['cqgsini','qgsect','qgini','qgconf','qgreg','chepevt','qgcrossc','cqgshh_ha_cs']
 urqmd_syms        = [
   'urqmd','init','uinit','set0','params','uounit','strini','loginit','loadwtab',

--- a/src/chromo/models/sibyll.py
+++ b/src/chromo/models/sibyll.py
@@ -111,10 +111,13 @@ class SibyllEvent(MCEvent):
         return self._lib.schg.ichg[:npart]
 
     def _get_impact_parameter(self):
-        return self._lib.cnucms.b
+        return self._lib.cnucms.b if self._lib.cnucms.na > 0 else self._lib.s_cncm0.b
 
     def _get_n_wounded(self):
-        return self._lib.cnucms.na, self._lib.cnucms.nb
+        na =  self._lib.cnucms.na if self._lib.cnucms.na > 0 else 1
+        nb =  self._lib.cnucms.nb if self._lib.cnucms.nb > 0 else self._lib.s_cncm0.na # Handle hadron-Nucleus case
+
+        return na, nb
 
     def _history_zero_indexing(self):
         # Sibyll has only mothers

--- a/src/chromo/models/sibyll.py
+++ b/src/chromo/models/sibyll.py
@@ -114,8 +114,10 @@ class SibyllEvent(MCEvent):
         return self._lib.cnucms.b if self._lib.cnucms.na > 0 else self._lib.s_cncm0.b
 
     def _get_n_wounded(self):
-        na =  self._lib.cnucms.na if self._lib.cnucms.na > 0 else 1
-        nb =  self._lib.cnucms.nb if self._lib.cnucms.nb > 0 else self._lib.s_cncm0.na # Handle hadron-Nucleus case
+        na = self._lib.cnucms.na if self._lib.cnucms.na > 0 else 1
+        nb = (
+            self._lib.cnucms.nb if self._lib.cnucms.nb > 0 else self._lib.s_cncm0.na
+        )  # Handle hadron-Nucleus case
 
         return na, nb
 

--- a/tests/test_sibyll.py
+++ b/tests/test_sibyll.py
@@ -126,7 +126,6 @@ def check_wounded(model, kin):
     gen = model(kin)
     gen.set_stable(111)
 
-
     wounded_na_list = []
     wounded_nb_list = []
     wounded_b_list = []
@@ -141,20 +140,20 @@ def check_wounded(model, kin):
         # Check wounded candidates [Main check]
         wounded_na, wounded_nb = event.n_wounded[0], event.n_wounded[1]
         wounded_b = event.impact_parameter
-        wounded_na_list.append(wounded_na !=0)
-        wounded_nb_list.append(wounded_nb !=0)
-        wounded_b_list.append(wounded_b !=0)
+        wounded_na_list.append(wounded_na != 0)
+        wounded_nb_list.append(wounded_nb != 0)
+        wounded_b_list.append(wounded_b != 0)
 
         # Check cnucms status [Detail check]
         cnucms_na, cnucms_nb = event._lib.cnucms.na, event._lib.cnucms.nb
         cnucms_b = event.impact_parameter
-        cnucms_na_list.append(cnucms_na !=0)
-        cnucms_nb_list.append(cnucms_nb !=0)
-        cnucms_b_list.append(cnucms_b !=0)
+        cnucms_na_list.append(cnucms_na != 0)
+        cnucms_nb_list.append(cnucms_nb != 0)
+        cnucms_b_list.append(cnucms_b != 0)
 
         # Check s_cncm0 status [Detail check]
-        s_cncm0_na_list.append(event._lib.s_cncm0.na !=0)
-        s_cncm0_b_list.append(event._lib.s_cncm0.b !=0)
+        s_cncm0_na_list.append(event._lib.s_cncm0.na != 0)
+        s_cncm0_b_list.append(event._lib.s_cncm0.b != 0)
 
     main_errors = []
     detail_errors = []
@@ -182,22 +181,35 @@ def check_wounded(model, kin):
 
 @pytest.mark.parametrize("model", get_sibylls())
 def test_wounded_proton_proton(model):
-    pytest.xfail(reason="No impact parameter in proton-proton collision, neither in " \
-    "event._lib.s_cncm0.b or event._lib.cnucms.b")
-    main_errors, detail_errors = run_in_separate_process(check_wounded, model, CenterOfMass(5 * TeV, "p", "p"))
+    pytest.xfail(
+        reason="No impact parameter in proton-proton collision, neither in "
+        "event._lib.s_cncm0.b or event._lib.cnucms.b"
+    )
+    main_errors, detail_errors = run_in_separate_process(
+        check_wounded, model, CenterOfMass(5 * TeV, "p", "p")
+    )
     assert not main_errors
+
 
 @pytest.mark.parametrize("model", get_sibylls())
 def test_wounded_proton_nucleus(model):
-    main_errors, detail_errors = run_in_separate_process(check_wounded, model, CenterOfMass(5 * TeV, "p", (16, 8)))
+    main_errors, detail_errors = run_in_separate_process(
+        check_wounded, model, CenterOfMass(5 * TeV, "p", (16, 8))
+    )
     assert not main_errors
+
 
 @pytest.mark.parametrize("model", get_sibylls())
 def test_wounded_nucleus_proton(model):
-    main_errors, detail_errors = run_in_separate_process(check_wounded, model, CenterOfMass(5 * TeV, (16, 8), "p"))
+    main_errors, detail_errors = run_in_separate_process(
+        check_wounded, model, CenterOfMass(5 * TeV, (16, 8), "p")
+    )
     assert not main_errors
+
 
 @pytest.mark.parametrize("model", get_sibylls())
 def test_wounded_nucleus_nucleus(model):
-    main_errors, detail_errors = run_in_separate_process(check_wounded, model, CenterOfMass(5 * TeV, (16, 8), (16, 8)))
+    main_errors, detail_errors = run_in_separate_process(
+        check_wounded, model, CenterOfMass(5 * TeV, (16, 8), (16, 8))
+    )
     assert not main_errors


### PR DESCRIPTION
## Problem and The way to fix it  [Fix #225]
We found there are no non-zero array of wounded candidates and the impact parameters in the proton-proton and proton-nucleus collision
To fix this, we try accessing the `s_cncm0` common block by adding `int_h_nuc` to the `sibyll_syms_base` list in `meson.build`, and check whether wounded candidates appear on the `s_cncm0` side.

## Changes
- Add `int_h_nuc` to `sibyll_syms_base` list in the meson.build in order to add `s_cncm0` as the attribute of `event._lib`.
- Modify `src/chromo/models/sibyll.py` : if there are no wounded candidates in `cnucms` side, try getting those from `s_cncm0` side, same for impact parameter.
- Modify `tests/test_sibyll.py` : Check out that wounded candidates appeared correctly or not.
- Passed through pytest successfully.

## Table of wounded particle presence
|                              | pp   | pO   | Op   | OO   |
|--------------------|------|------|------|------|
| wounded_na exist  | True | True | True | True |
| wounded_nb exist  | True | True | True | True |
| wounded_b exist   | False| True | True | True |
| cnucms_na exist    | False| False| True | True |
| cnucms_nb exist    | False| False| True | True |
| cnucms_b exist     | False| False| True | True |
| s_cncm0_na exist   | True | True | True | True |
| s_cncm0_b exist    | False| True | False| True |

- pp : Impact parameter does not exist on neither `s_cncm0` or `cnucms ` side, but found wounded candidates in `s_cncm0` side.
- pO : Using impact parameter and wounded candidates via `s_cncm0`.
- Op : Using impact parameter and wounded candidates via `cnucms`.
- OO: Using impact parameter and wounded candidates via `cnucms`.

## Simple script of checking the parameter:
```python
    from chromo.models import (Sibyll21, 
    Sibyll23c, Sibyll23d, Sibyll23dStarMixed, Sibyll23e, Sibyll23eStarMixed)

    models = [Sibyll21, 
    Sibyll23c, Sibyll23d, Sibyll23dStarMixed, Sibyll23e, Sibyll23eStarMixed
    ]

    kins = [CenterOfMass(5 * TeV, "p", "p"),         
            CenterOfMass(5 * TeV, "p", (16, 8)),     
            CenterOfMass(5 * TeV, (16, 8), "p"),     
            CenterOfMass(5 * TeV, (16, 8), (16, 8)), 
            ]
    
    info_list = []

    for model in models:
        kin = kins[3] # Change to others case
        gen = model(kin)
        gen.set_stable(111)    

        wounded_na = []
        wounded_nb = []
        wounded_b = []

        cnucms_na_list = []
        cnucms_nb_list = []
        cnucms_b_list = []
        s_cncm0_na_list = []
        s_cncm0_b_list = []

        for event in gen(10):

            # wounded status
            wounded_na.append(event.n_wounded[0] !=0)
            wounded_nb.append(event.n_wounded[1] !=0)
            wounded_b.append(event.impact_parameter !=0)

            # Check cnucms status
            cnucms_na, cnucms_nb = event._lib.cnucms.na, event._lib.cnucms.nb
            cnucms_b = event._lib.cnucms.b

            cnucms_na_list.append(cnucms_na !=0)
            cnucms_nb_list.append(cnucms_nb !=0)
            cnucms_b_list.append(cnucms_b !=0)

            # Check s_cncm0 status
            s_cncm0_na_list.append(event._lib.s_cncm0.na !=0)
            s_cncm0_b_list.append(event._lib.s_cncm0.b !=0)

        info_list.append('='*30)
        info_list.append(f'{gen.label=} | wounded_na {any(wounded_na)}')
        info_list.append(f'{gen.label=} | wounded_nb {any(wounded_nb)}')
        info_list.append(f'{gen.label=} | wounded_b {any(wounded_b)}')

        info_list.append(f'{gen.label=} | cnucms_na_list {any(cnucms_na_list)}')
        info_list.append(f'{gen.label=} | cnucms_nb_list {any(cnucms_nb_list)}')
        info_list.append(f'{gen.label=} | cnucms_b_list {any(cnucms_b_list)}')

        info_list.append(f'{gen.label=} | s_cncm0_na_list {any(s_cncm0_na_list)}')
        info_list.append(f'{gen.label=} | s_cncm0_b_list {any(s_cncm0_b_list)}')

    for info in info_list:
        print(info)
```