### PR TITLE
BUGFIX: Fix charge sibyll sign

### DIFF
--- a/src/fortran/sibyll/sibyll_init.f
+++ b/src/fortran/sibyll/sibyll_init.f
@@ -65,7 +65,7 @@ C-----------------------------------------------------------------------
          ELSE
             ISTHEP(I) = 2
          END IF
-         ICHG(I) = ICHP(ABS(MOD(LLIST(I),10000)))
+         ICHG(I) = sign(1, LLIST(I)) * ICHP(ABS(MOD(LLIST(I),10000)))
          IDHEP(I) = ISIB_PID2PDG(MOD(LLIST(I),10000))
          JMOHEP(1,I) = LLIST1(I)
          JMOHEP(2,I) = LLIST1(I)

--- a/tests/test_sibyll.py
+++ b/tests/test_sibyll.py
@@ -55,7 +55,6 @@ def event_run(model):
 
 @pytest.mark.parametrize("model", get_sibylls())
 def test_charge(model):
-    pytest.xfail(reason="The SIBYLL charge test needs a fix.")
     event = run_in_separate_process(event_run, model)
     expected = reference_charge(event.pid)
     assert_allclose(event.charge, expected)


### PR DESCRIPTION
This fixes the sign of the charge in the Sibyll middle fortran layer to make `test_charge` pass.