### PR TITLE
🖌️  Remove NaN prod CS from SIBYLL wrapper

### DIFF
--- a/src/chromo/models/sibyll.py
+++ b/src/chromo/models/sibyll.py
@@ -204,8 +204,7 @@ class SIBYLLRun(MCRun):
             kin.p1
         ):
             warnings.warn(
-                f"Cross section for {kin.p1} projectiles not "
-                f"supported in {self.label}",
+                f"Cross section for {kin.p1} projectiles not supported in {self.label}",
                 RuntimeWarning,
             )
             return CrossSectionData()
@@ -233,11 +232,7 @@ class SIBYLLRun(MCRun):
             nsig = self._lib.nucsig
             return CrossSectionData(
                 total=float(nsig.sigt),
-                prod=(
-                    float(nsig.sigt - nsig.sigqe)
-                    if not np.isnan(nsig.sigqe)
-                    else float(nsig.siginel)
-                ),
+                prod=float(nsig.sigt - nsig.sigqe),
                 quasielastic=float(nsig.sigqe),
                 inelastic=float(nsig.siginel),
                 diffractive_sum=float(nsig.sigqsd),

--- a/tests/test_cross_sections.py
+++ b/tests/test_cross_sections.py
@@ -37,7 +37,12 @@ def test_generator(projectile, target, Model):
         # cannot use Argon in SIBYLL, so make air from N, O only
         p2 = CompositeTarget((("N", 0.78), ("O", 0.22)))
 
-    kin = CenterOfMass(100 * GeV, p1, p2)
+    # increase energy for K+ and SIBYLL23c to avoid prod cs = nan region
+    # this is specifig to SIBYLL23C
+    if Model == im.Sibyll23c and projectile == "K+" and target == "air":
+        kin = CenterOfMass(1e3 * GeV, p1, p2)
+    else:
+        kin = CenterOfMass(100 * GeV, p1, p2)
 
     ret = run_in_separate_process(run_model, Model, kin)
     if ret is None:


### PR DESCRIPTION
For kaons-air sibyll returns nan production cross sections. Chromo is overwriting this, which should not happen. It should expose the nans of the generator to the user.

https://github.com/impy-project/chromo/blob/c2d88b4cc0dc843b19ff59596224aa635e419b66/src/chromo/models/sibyll.py#L236-L239

Small fix 😊 