### PR TITLE
Add example how to use custom decay handler

### DIFF
--- a/examples/decayhandler.ipynb
+++ b/examples/decayhandler.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c4be1e85",
+   "metadata": {},
+   "source": [
+    "# Simulating decays in pythia using chromo's fast vectorized interface\n",
+    "\n",
+    "This example demonstrates how to use the `DecayHandler` class from chromo to simulate decays using pythia 8 decay routines. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "79ca4171",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chromo.kinematics import FixedTarget, KinEnergy\n",
+    "from chromo.decay_handler import Pythia8DecayHandler\n",
+    "from chromo.common import EventData\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from particle import Particle\n",
+    "import boost_histogram as bh\n",
+    "from chromo.util import EventFrame\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "be3d5cbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These are all hadrons up to bottom, plus leptons and photons\n",
+    "stable_list = Particle.findall(\n",
+    "    lambda p: not (\n",
+    "        abs(p.pdgid) < 11\n",
+    "        or abs(p.pdgid) in [21, 22]\n",
+    "        or (22 < abs(p.pdgid) < 111)\n",
+    "        or abs(p.pdgid) > 5000\n",
+    "        or p.pdgid.has_bottom\n",
+    "        or (p.mass is None)\n",
+    "        or (p.pdgid.is_lepton and abs(p.pdgid) not in [15, 13])\n",
+    "    ),\n",
+    "    particle=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c84bd5ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mu- 105.6583755 <PDGID: 13>\n",
+      "tau- 1776.93 <PDGID: 15>\n",
+      "pi0 134.9768 <PDGID: 111>\n",
+      "rho(770)0 775.26 <PDGID: 113>\n",
+      "a(2)(1320)0 1318.2 <PDGID: 115>\n",
+      "rho(3)(1690)0 1688.8 <PDGID: 117>\n",
+      "a(4)(1970)0 1967.0 <PDGID: 119>\n",
+      "K(L)0 497.611 <PDGID: 130>\n",
+      "pi+ 139.57039 <PDGID: 211>\n",
+      "rho(770)+ 775.11 <PDGID: 213>\n",
+      "a(2)(1320)+ 1318.2 <PDGID: 215>\n",
+      "rho(3)(1690)+ 1688.8 <PDGID: 217>\n",
+      "a(4)(1970)+ 1967.0 <PDGID: 219>\n",
+      "eta 547.862 <PDGID: 221>\n",
+      "omega(782) 782.66 <PDGID: 223>\n",
+      "f(2)(1270) 1275.4 <PDGID: 225>\n",
+      "omega(3)(1670) 1667.0 <PDGID: 227>\n",
+      "f(4)(2050) 2018.0 <PDGID: 229>\n",
+      "K(S)0 497.611 <PDGID: 310>\n",
+      "K0 497.611 <PDGID: 311>\n",
+      "K*(892)0 895.55 <PDGID: 313>\n"
+     ]
+    }
+   ],
+   "source": [
+    "counts = 0\n",
+    "for p in stable_list:\n",
+    "    print(p, p.mass, p.pdgid)\n",
+    "    counts += 1\n",
+    "    if counts > 20:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "70e1cb4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "105"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(stable_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7087e9f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "py8decays = Pythia8DecayHandler(stable_pids=[p.pdgid for p in stable_list])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "841e9fdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def put_on_stack(projectile, n_copies=1):\n",
+    "    # Customize arguments if want to pass custom energy or momenta\n",
+    "    # Pass en, pz, etc. further down below\n",
+    "    m = projectile.mass * 1e-3\n",
+    "    # Silence warning\n",
+    "    with np.errstate(invalid='ignore'):\n",
+    "        kin = FixedTarget(KinEnergy(0.0), projectile.pdgid, 2212)\n",
+    "    # Initialize an EventData object with empty arrays\n",
+    "    event = EventData(\n",
+    "        generator=(\"\", \"\"),  # Empty generator name and version\n",
+    "        kin=kin,  # kinematics\n",
+    "        nevent=0,  # Event number\n",
+    "        impact_parameter=0.0,  # Impact parameter in mm\n",
+    "        n_wounded=(0, 0),  # Number of wounded nucleons on sides A and B\n",
+    "        production_cross_section=0.0,  # Production cross section in mb\n",
+    "        pid=np.zeros(n_copies, dtype=int),  # Empty PDG ID array\n",
+    "        status=np.zeros(n_copies, dtype=int),  # Empty status array\n",
+    "        charge=np.zeros(n_copies, dtype=float),  # Empty charge array\n",
+    "        px=np.zeros(n_copies, dtype=float),  # Empty px momentum array\n",
+    "        py=np.zeros(n_copies, dtype=float),  # Empty py momentum array\n",
+    "        pz=np.zeros(n_copies, dtype=float),  # Empty pz momentum array\n",
+    "        en=np.zeros(n_copies, dtype=float),  # Empty energy array\n",
+    "        m=np.zeros(n_copies, dtype=float),  # Empty mass array\n",
+    "        vx=np.zeros(n_copies, dtype=float),  # Empty vx position array\n",
+    "        vy=np.zeros(n_copies, dtype=float),  # Empty vy position array\n",
+    "        vz=np.zeros(n_copies, dtype=float),  # Empty vz position array\n",
+    "        vt=np.zeros(n_copies, dtype=float),  # Empty vt time array\n",
+    "        mothers=None,  # No mother information\n",
+    "        daughters=None,  # No daughter information\n",
+    "    )\n",
+    "    event.en[:] = m\n",
+    "    event.m[:] = m\n",
+    "    event.pid[:] = projectile.pdgid\n",
+    "    event.status[:] = 1\n",
+    "\n",
+    "    return event"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "0b49c1cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose projectile\n",
+    "pid = 321  # K+\n",
+    "projectile = Particle.from_pdgid(pid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "885eb490",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Particle K+ is in stable_list True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Particle {projectile} is in stable_list {projectile in stable_list}\")\n",
+    "# Make unstable so it can decay in pythia\n",
+    "py8decays.pythia.particleData.mayDecay(pid, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "5f194d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: customize options using standard pythia string interface\n",
+    "# py8decays.pythia.readString(\"321:onMode = on\")  # activate all channels\n",
+    "# py8decays.pythia.readString(\n",
+    "#     \"321:offIfMatch = -13 14\"\n",
+    "# ) # Disable 2-body decays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "4b60573c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a new event and put n_copies projectiles on the stack (if you want to let many of the particles decay)\n",
+    "event = put_on_stack(projectile, n_copies=1)  # Use a single particle to decay here\n",
+    "# Run pythia decays\n",
+    "py8decays(event)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "3da819b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 211 0.14636128053809327 -0.04276702215882962\n",
+      "1 211 0.18480564612656492 0.11068673200545695\n",
+      "2 -211 0.16251007333534181 -0.06791970984662735\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Look only at final state particles\n",
+    "ev = event.final_state()\n",
+    "# Access the event in standard chromo way.\n",
+    "# The decay products are always appended to the end of the original arrays with status 1 (no\n",
+    "# need to care about this if using final_state() as shown here.)\n",
+    "for i, p in enumerate(range(len(ev.pid))):\n",
+    "    print(i, ev.pid[i], ev.elab[i], ev.pz[i])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5385cbd7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv312wsl",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This example demonstrates how to simulate particle decays using chromo's custom pythia 8 interface. It supports batched decays that don't leave the fast C++ environment to simulate millions of decays very quickly.