### PR TITLE
Allow for interactions of exotic particles (including charm) in DPMJET interface

### DIFF
--- a/examples/decayhandler.ipynb
+++ b/examples/decayhandler.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c4be1e85",
+   "metadata": {},
+   "source": [
+    "# Simulating decays in pythia using chromo's fast vectorized interface\n",
+    "\n",
+    "This example demonstrates how to use the `DecayHandler` class from chromo to simulate decays using pythia 8 decay routines. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "79ca4171",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chromo.kinematics import FixedTarget, KinEnergy\n",
+    "from chromo.decay_handler import Pythia8DecayHandler\n",
+    "from chromo.common import EventData\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from particle import Particle\n",
+    "import boost_histogram as bh\n",
+    "from chromo.util import EventFrame\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "be3d5cbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These are all hadrons up to bottom, plus leptons and photons\n",
+    "stable_list = Particle.findall(\n",
+    "    lambda p: not (\n",
+    "        abs(p.pdgid) < 11\n",
+    "        or abs(p.pdgid) in [21, 22]\n",
+    "        or (22 < abs(p.pdgid) < 111)\n",
+    "        or abs(p.pdgid) > 5000\n",
+    "        or p.pdgid.has_bottom\n",
+    "        or (p.mass is None)\n",
+    "        or (p.pdgid.is_lepton and abs(p.pdgid) not in [15, 13])\n",
+    "    ),\n",
+    "    particle=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c84bd5ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mu- 105.6583755 <PDGID: 13>\n",
+      "tau- 1776.93 <PDGID: 15>\n",
+      "pi0 134.9768 <PDGID: 111>\n",
+      "rho(770)0 775.26 <PDGID: 113>\n",
+      "a(2)(1320)0 1318.2 <PDGID: 115>\n",
+      "rho(3)(1690)0 1688.8 <PDGID: 117>\n",
+      "a(4)(1970)0 1967.0 <PDGID: 119>\n",
+      "K(L)0 497.611 <PDGID: 130>\n",
+      "pi+ 139.57039 <PDGID: 211>\n",
+      "rho(770)+ 775.11 <PDGID: 213>\n",
+      "a(2)(1320)+ 1318.2 <PDGID: 215>\n",
+      "rho(3)(1690)+ 1688.8 <PDGID: 217>\n",
+      "a(4)(1970)+ 1967.0 <PDGID: 219>\n",
+      "eta 547.862 <PDGID: 221>\n",
+      "omega(782) 782.66 <PDGID: 223>\n",
+      "f(2)(1270) 1275.4 <PDGID: 225>\n",
+      "omega(3)(1670) 1667.0 <PDGID: 227>\n",
+      "f(4)(2050) 2018.0 <PDGID: 229>\n",
+      "K(S)0 497.611 <PDGID: 310>\n",
+      "K0 497.611 <PDGID: 311>\n",
+      "K*(892)0 895.55 <PDGID: 313>\n"
+     ]
+    }
+   ],
+   "source": [
+    "counts = 0\n",
+    "for p in stable_list:\n",
+    "    print(p, p.mass, p.pdgid)\n",
+    "    counts += 1\n",
+    "    if counts > 20:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "70e1cb4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "105"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(stable_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7087e9f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "py8decays = Pythia8DecayHandler(stable_pids=[p.pdgid for p in stable_list])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "841e9fdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def put_on_stack(projectile, n_copies=1):\n",
+    "    # Customize arguments if want to pass custom energy or momenta\n",
+    "    # Pass en, pz, etc. further down below\n",
+    "    m = projectile.mass * 1e-3\n",
+    "    # Silence warning\n",
+    "    with np.errstate(invalid='ignore'):\n",
+    "        kin = FixedTarget(KinEnergy(0.0), projectile.pdgid, 2212)\n",
+    "    # Initialize an EventData object with empty arrays\n",
+    "    event = EventData(\n",
+    "        generator=(\"\", \"\"),  # Empty generator name and version\n",
+    "        kin=kin,  # kinematics\n",
+    "        nevent=0,  # Event number\n",
+    "        impact_parameter=0.0,  # Impact parameter in mm\n",
+    "        n_wounded=(0, 0),  # Number of wounded nucleons on sides A and B\n",
+    "        production_cross_section=0.0,  # Production cross section in mb\n",
+    "        pid=np.zeros(n_copies, dtype=int),  # Empty PDG ID array\n",
+    "        status=np.zeros(n_copies, dtype=int),  # Empty status array\n",
+    "        charge=np.zeros(n_copies, dtype=float),  # Empty charge array\n",
+    "        px=np.zeros(n_copies, dtype=float),  # Empty px momentum array\n",
+    "        py=np.zeros(n_copies, dtype=float),  # Empty py momentum array\n",
+    "        pz=np.zeros(n_copies, dtype=float),  # Empty pz momentum array\n",
+    "        en=np.zeros(n_copies, dtype=float),  # Empty energy array\n",
+    "        m=np.zeros(n_copies, dtype=float),  # Empty mass array\n",
+    "        vx=np.zeros(n_copies, dtype=float),  # Empty vx position array\n",
+    "        vy=np.zeros(n_copies, dtype=float),  # Empty vy position array\n",
+    "        vz=np.zeros(n_copies, dtype=float),  # Empty vz position array\n",
+    "        vt=np.zeros(n_copies, dtype=float),  # Empty vt time array\n",
+    "        mothers=None,  # No mother information\n",
+    "        daughters=None,  # No daughter information\n",
+    "    )\n",
+    "    event.en[:] = m\n",
+    "    event.m[:] = m\n",
+    "    event.pid[:] = projectile.pdgid\n",
+    "    event.status[:] = 1\n",
+    "\n",
+    "    return event"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "0b49c1cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose projectile\n",
+    "pid = 321  # K+\n",
+    "projectile = Particle.from_pdgid(pid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "885eb490",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Particle K+ is in stable_list True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Particle {projectile} is in stable_list {projectile in stable_list}\")\n",
+    "# Make unstable so it can decay in pythia\n",
+    "py8decays.pythia.particleData.mayDecay(pid, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "5f194d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: customize options using standard pythia string interface\n",
+    "# py8decays.pythia.readString(\"321:onMode = on\")  # activate all channels\n",
+    "# py8decays.pythia.readString(\n",
+    "#     \"321:offIfMatch = -13 14\"\n",
+    "# ) # Disable 2-body decays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "4b60573c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a new event and put n_copies projectiles on the stack (if you want to let many of the particles decay)\n",
+    "event = put_on_stack(projectile, n_copies=1)  # Use a single particle to decay here\n",
+    "# Run pythia decays\n",
+    "py8decays(event)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "3da819b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 211 0.14636128053809327 -0.04276702215882962\n",
+      "1 211 0.18480564612656492 0.11068673200545695\n",
+      "2 -211 0.16251007333534181 -0.06791970984662735\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Look only at final state particles\n",
+    "ev = event.final_state()\n",
+    "# Access the event in standard chromo way.\n",
+    "# The decay products are always appended to the end of the original arrays with status 1 (no\n",
+    "# need to care about this if using final_state() as shown here.)\n",
+    "for i, p in enumerate(range(len(ev.pid))):\n",
+    "    print(i, ev.pid[i], ev.elab[i], ev.pz[i])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5385cbd7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv312wsl",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/chromo/models/dpmjetIII.py
+++ b/src/chromo/models/dpmjetIII.py
@@ -9,6 +9,37 @@ from chromo.util import (
     fortran_chars,
     info,
 )
+from particle import Particle
+
+# The list below are all known particles to DPMJET, which can be used as
+# projectiles. To generate this list, run the following script:
+# ```python
+# from particle import Particle
+# projectile_list = Particle.findall(
+#     lambda p: not (
+#         abs(p.pdgid) < 11
+#         or abs(p.pdgid) in [21, 22]
+#         or (22 < abs(p.pdgid) < 111)
+#         or abs(p.pdgid) > 5000
+#         or p.pdgid.has_bottom
+#         or (p.mass is None)
+#         or (p.pdgid.is_lepton)
+#         or dpm._lib.idt_icihad(p.pdgid) == 0
+#     ),
+#     particle=True,
+# )
+# print(set([int(p.pdgid) for p in projectile_list]))
+# ```
+# fmt: off
+dpmjet_extended_projectiles = {
+    130, 3334, 4232, 3212, 3214, 3216, 4112, 3218, 3222, 3224,
+    4122, 411, 413, 2212, 421, 2214, 423, 3112, 4132, 3114,
+    431, 2224, 433, 3122, 310, 311, 313, 441, 443, 2112,
+    321, 2114, 323, 331, 333, 211, 213, 1114, 221, 223,
+    111, 3312, 113, 3314, 4212, 3322, 3324, 4222
+}
+dpmjet_extended_projectiles = {Particle.from_pdgid(p).pdgid for p in dpmjet_extended_projectiles}
+# fmt: on
 
 
 class DpmjetIIIEvent(MCEvent):
@@ -42,7 +73,7 @@ class DpmjetIIIEvent(MCEvent):
     def _prepare_for_hepmc(self):
         model, version = self.generator
         warnings.warn(
-            f"{model}-{version}: only part of the history " "available in HepMC3 event",
+            f"{model}-{version}: only part of the history available in HepMC3 event",
             RuntimeWarning,
         )
         mask = (
@@ -77,7 +108,7 @@ class DpmjetIIIRun(MCRun):
     _event_class = DpmjetIIIEvent
     _frame = None
     # TODO: DPMJet supports photons as projectiles
-    _projectiles = standard_projectiles | Nuclei() | {3322, 3312, 3222, 3122, 3112, 311}
+    _projectiles = dpmjet_extended_projectiles | Nuclei(a_max=280)
     _targets = Nuclei()
     _param_file_name = "dpmjpar.dat"
     _evap_file_name = "dpmjet.dat"
@@ -283,15 +314,11 @@ class DpmjetIIIRun(MCRun):
 
 class DpmjetIII191(DpmjetIIIRun):
     _version = "19.1"
-    _projectiles = standard_projectiles | Nuclei() | {3322, 3312, 3222, 3122, 3112, 311}
     _library_name = "_dpmjet191"
 
 
 class DpmjetIII193(DpmjetIII191):
     _version = "19.3"
-    _projectiles = (
-        standard_projectiles | Nuclei() | {3322, 3312, 3222, 3122, 3112, 311, 22}
-    )
     _library_name = "_dpmjet193"
 
 
@@ -308,7 +335,4 @@ class DpmjetIII307(DpmjetIIIRun):
 
 class DpmjetIII193_DEV(DpmjetIIIRun):
     _version = "19.3-dev"
-    _projectiles = (
-        standard_projectiles | Nuclei() | {3322, 3312, 3222, 3122, 3112, 311, 22}
-    )
     _library_name = "_dev_dpmjet193"

--- a/tests/test_dpmjetIII.py
+++ b/tests/test_dpmjetIII.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 
 import chromo
 from chromo.constants import GeV
-from chromo.util import naneq
+from chromo.util import get_all_models, naneq
 
 from .util import run_in_separate_process
 
@@ -15,15 +15,33 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def run_cross_section(p1, p2):
+def get_dpmjets(no307=False):
+    """Get the list of all DPMJets"""
+    return [
+        cl
+        for cl in get_all_models()
+        if cl.pyname.startswith("Dpmjet") and (not no307 or cl.pyname != "DpmjetIII307")
+    ]
+
+
+def run_cross_section(p1, p2, model):
     evt_kin = chromo.kinematics.CenterOfMass(10 * GeV, p1, p2)
-    m = chromo.models.DpmjetIII193(evt_kin, seed=1)
+    m = model(evt_kin, seed=1)
     return m.cross_section(max_info=True)
 
 
-def run_cross_section_ntrials():
+def run_three_events(p1, model):
+    chromo.debug_level = 1
+    evt_kin = chromo.kinematics.CenterOfMass(100 * GeV, p1, "O16")
+    m = model(evt_kin, seed=1)
+    for evt in m(3):
+        evt = evt.final_state()
+        assert len(evt.en) > 0
+
+
+def run_cross_section_ntrials(model):
     event_kin = chromo.kinematics.FixedTarget(1e4, "proton", "O16")
-    event_generator = chromo.models.DpmjetIII193(event_kin)
+    event_generator = model(event_kin)
 
     air = chromo.util.CompositeTarget([("N", 0.78), ("O", 0.22)])
     event_kin = chromo.kinematics.FixedTarget(1e3, "proton", air)
@@ -59,12 +77,14 @@ def run_cross_section_ntrials():
     assert np.std(cross_section_run1) > np.std(cross_section_run2)
 
 
-def test_cross_section_ntrials():
-    run_in_separate_process(run_cross_section_ntrials)
+@pytest.mark.parametrize("model", get_dpmjets())
+def test_cross_section_ntrials(model):
+    run_in_separate_process(run_cross_section_ntrials, model)
 
 
-def test_cross_section_pp():
-    c = run_in_separate_process(run_cross_section, "p", "p")
+@pytest.mark.parametrize("model", get_dpmjets(no307=True))
+def test_cross_section_pp(model):
+    c = run_in_separate_process(run_cross_section, "p", "p", model)
     # These are the expected rounded numbers from the DPMJET
     # for pp at 10 GeV
     assert_allclose(c.total, 38.9, atol=0.1)
@@ -80,8 +100,9 @@ def test_cross_section_pp():
     naneq(c.diffractive_axb, np.nan)
 
 
-def test_cross_section_pA():
-    c = run_in_separate_process(run_cross_section, "p", "O16")
+@pytest.mark.parametrize("model", get_dpmjets(no307=True))
+def test_cross_section_pA(model):
+    c = run_in_separate_process(run_cross_section, "p", "O16", model)
     assert_allclose(c.total, 446.1, atol=0.1)
     assert_allclose(c.inelastic, 328.0, atol=0.1)
     assert_allclose(c.elastic, 118.1, atol=0.1)
@@ -95,3 +116,23 @@ def test_cross_section_pA():
     naneq(c.diffractive_xb, np.nan)
     naneq(c.diffractive_xx, np.nan)
     naneq(c.diffractive_axb, np.nan)
+
+
+def get_model_projectile_combinations():
+    """Get combinations of DPMJET models and their non-nuclei projectiles with PDG ID < 6000"""
+    return [
+        (model, int(pid))
+        for model in get_dpmjets()
+        for pid in getattr(model.projectiles, "_other", set())
+        if int(pid) < 6000
+    ]
+
+
+@pytest.mark.parametrize("model,p1", get_model_projectile_combinations())
+def test_projectile_list(model, p1):
+    run_in_separate_process(run_three_events, p1, model)
+
+
+@pytest.mark.parametrize("model,p1", get_model_projectile_combinations())
+def test_all_projectiles(model, p1):
+    run_in_separate_process(run_three_events, p1, model)


### PR DESCRIPTION
The DPMJET-III-19+ models contain routines to split particles up into their quark content and to simulate their interactions. While the approach is in no way sophisticated, it gives some more realistic treatment for the flavor content of leading particles at string ends.

Implementation:

- Create a list of particles accepted by the generator with no errors or warnings.
- Use the list in the `projectiles` attribute of the model classes
- Test all allowed combinations  