### PR TITLE
CD: Remove fortran install for macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,15 +108,7 @@ jobs:
         if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         run: echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-13' && '13.0' || matrix.os == 'macos-14' && '14.0' || '' }}" >> $GITHUB_ENV
 
-      - if: ${{ matrix.os == 'macos-13' }}
-        name: Install gfortran via Homebrew
-        run: |
-          brew install gcc
-          gfortran --version
-          which gfortran
-
-      - if: ${{ matrix.os != 'macos-13'}}
-        name: Setup gfortran
+      - name: Setup gfortran
         uses: awvwgk/setup-fortran@v1.6.1
         id: setup-fortran
         with:


### PR DESCRIPTION
This fixes the CD workflow fail for macOS-13 described here: #236 

Solution is just removing the macOS-13 gcc/gfortran install. I assume the reason it was put into the CD is that the setup-fortran action failed with Meson, but it seems that the problem solved itself according to this issue: https://github.com/fortran-lang/setup-fortran/issues/32

The build succeeded on my fork: https://github.com/StFroese/chromo/actions/runs/18517983630/job/52772130202