### PR TITLE
CI: Added a label to skip CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   prepare-cache:
+    if: contains(github.event.pull_request.labels.*.name, 'skip CI') == false
     runs-on: ubuntu-latest
     steps:
       - name: Restore chromo data cache


### PR DESCRIPTION
Closes #238. 
If a PR does not change the source code one might want to skip the CI tests since they can be quite extensive.
This is implement by checking if the PR is labeled as `skip CI`