### PR TITLE
EPOS: raise HEPEVT particle limit nmxhep 9990 -> 100000

### DIFF
--- a/src/fortran/epos-lhc-r/sources/epos.inc
+++ b/src/fortran/epos-lhc-r/sources/epos.inc
@@ -10,7 +10,7 @@ c---------------------------------------------------------------------------
       parameter (mmry=1)   !memory saving factor
 
       parameter (mxptl=300000/mmry) !max nr of particles in epos ptl list
-      parameter (nmxhep=9990)    !max nr of particles in hep ptl list
+      parameter (nmxhep=100000)    !max nr of particles in hep ptl list
       parameter (myptl=1000)        !max nr of droplets in epos ptl list
       parameter (nzeta=60)          !max nr of zeta bins for droplets
       parameter (nflav=6)           !max nr of flavors

--- a/src/fortran/epos-lhc/sources/epos.inc
+++ b/src/fortran/epos-lhc/sources/epos.inc
@@ -9,7 +9,7 @@ c---------------------------------------------------------------------------
       parameter (mmry=1)   !memory saving factor
 
       parameter (mxptl=INT(200000/mmry)) !max nr of particles in epos ptl list
-      parameter (nmxhep=9990)       !max nr of particles in hep ptl list
+      parameter (nmxhep=100000)       !max nr of particles in hep ptl list
       parameter (myptl=1000)        !max nr of droplets in epos ptl list
       parameter (nzeta=60)          !max nr of zeta bins for droplets
       parameter (nflav=6)           !max nr of flavors


### PR DESCRIPTION
## Problem

`epos.inc` sets `parameter (nmxhep=9990)` for the HEPEVT block. Above that,
`epos-bas.f` prints

```
Warning : produced number of particles is too high
          Particle list is truncated at,  9990
          Skip event !
```

and drops the event. At cosmic-ray energies this is not rare, and it removes
*precisely* the highest-multiplicity events, biasing any inclusive spectrum.

Measured for p + dry air (N14/O16/Ar40) with EPOS LHC-R via chromo:

| E_kin | events over 9990 | max multiplicity seen |
|---|---|---|
| 4.47e10 GeV | 0.30 % | 14144 |
| 8.91e10 GeV | 1.23 % | 16239 |
| 8.91e11 GeV | **6.5 %** | 19102 |

With a **nuclear target** it is worse than a bias: the truncated event leaves a
degenerate record, and `_repair_initial_beam` then raises

```
IndexError: index 1 is out of bounds for axis 0 with size 1
```

in `_beam_mother_daughters_fix`, killing the process rather than the event. A
job that is simply retried is then silently conditioned on containing no
high-multiplicity event.

## Change

`nmxhep` 9990 -> 100000 in both `epos-lhc` and `epos-lhc-r`.

`nmxhep` only sizes the HEPEVT common block and the matching scratch arrays in
`epos-bas.f` (~96 B per slot, so ~1 MB -> ~10 MB). Verified to land in static
storage, not on the stack: the built extension's `.bss` grows 1977 -> 1995 MB,
and no stack-limit change is required. EPOS's own particle list (`mxptl` =
200000 for epos-lhc, 300000 for epos-lhc-r) retains ample headroom. The value
is set well clear of the observed distribution so the ceiling does not have to
be revisited.

## Testing

Rebuilt and ran against EPOS LHC-R:

- `hepevt.idhep.shape` is `(100000,)` for both `_eposlhc` and `_eposlhcr`
- 200 events at 8.913e11 GeV (p + air): no crashes, mean multiplicity 2498,
  max 19102 — i.e. events that the old limit destroyed now complete
- `tests/test_epos.py`: 10 passed
- EPOS selection across the suite: 242 passed, 36 skipped, 3 failed — and the
  3 failures are `test_models_beam`, which fail identically on an unpatched
  build (they are the `particle` 1.0.0 `Fraction` dtype issue addressed
  separately in #PR2)

Used in production for a 30,000-shard cosmic-ray yield-matrix run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01915awr3zv25frM1ctMAid6
