### PR TITLE
epos: do not crash on a degenerate (skipped) event record

### DIFF
--- a/src/chromo/models/epos.py
+++ b/src/chromo/models/epos.py
@@ -102,11 +102,21 @@ class EPOSEvent(MCEvent):
         """
         # Search among epos's beam particles the particles with the
         # same energy as projectile/target
+        # A generator can hand us a degenerate record: EPOS truncates and
+        # skips events whose multiplicity exceeds nmxhep, leaving nothing to
+        # attach the beam to. Without this guard the next line raises
+        # IndexError and kills the process instead of the event.
+        if len(event.en) <= ind:
+            return
         is_parent = np.isclose(event.en, event.en[ind], rtol=1e-2) & (event.status == 4)
         # Attach them to the parent
         event.mothers[is_parent] = [ind, -1]
         # Assign daughters for projectile/target
         daughters = np.where(is_parent)[0]
+        # No beam remnants matched: np.min/np.max on an empty array would
+        # raise ValueError.
+        if daughters.size == 0:
+            return
         event.daughters[ind] = [np.min(daughters), np.max(daughters)]
 
     def _repair_initial_beam(self):
@@ -119,6 +129,12 @@ class EPOSEvent(MCEvent):
 
         # Don't do anything if it's not a nucleus
         if not (np.any(is_nucleus)):
+            return
+
+        # Nothing to repair on a degenerate (skipped) event -- see the guard
+        # in _beam_mother_daughters_fix. Returning here keeps the empty event
+        # intact so the caller can drop it, rather than crashing the run.
+        if len(self.pid) == 0:
             return
 
         bstatus = 555  # status of prepended particles


### PR DESCRIPTION
## Problem

`_repair_initial_beam` crashes the whole run when a generator hands it a
degenerate (empty) event record:

```
chromo/models/epos.py in _beam_mother_daughters_fix
    is_parent = np.isclose(event.en, event.en[ind], rtol=1e-2) & (event.status == 4)
IndexError: index 1 is out of bounds for axis 0 with size 1
```

EPOS produces exactly such a record when it truncates and skips an event whose
multiplicity exceeds `nmxhep` (9990):

```
Warning : produced number of particles is too high
          Particle list is truncated at,  9990
          Skip event !
```

With a **nuclear target** the prepend logic then indexes position 1 of a
1-element array. A generator-level "skip this event" becomes a process-level
crash, which for a batch production means a lost job rather than a lost event.

This is not rare at cosmic-ray energies. Measured for p + dry air with
EPOS LHC-R:

| E_kin | events over 9990 particles |
|---|---|
| 4.47e10 GeV | 0.30 % |
| 8.91e10 GeV | 1.23 % |
| 8.91e11 GeV | **6.5 %** |

## Change

Three guards, all in `epos.py`:

1. `_beam_mother_daughters_fix`: return early if `len(event.en) <= ind` — the
   reported `IndexError`.
2. Same function: return early if no beam remnants matched, because
   `np.min`/`np.max` on the empty `daughters` array would raise `ValueError`.
   **This is a second latent crash on the same degenerate record** that the
   reported traceback never reached; fixing only the `IndexError` moves the
   failure two lines down.
3. `_repair_initial_beam`: return early when the event record is empty, so the
   empty event passes through intact for the caller to drop.

No behaviour change for well-formed events.

## Testing

Before/after in one run, same script, same seed, same build with the stock
`nmxhep=9990` so the truncation actually fires. EPOS LHC-R, p + air,
E_kin 8.913e11 GeV, 1500 events:

```
BEFORE:  Particle list is truncated at, 9990
         RESULT CRASH after n=7: IndexError: index 1 is out of bounds for axis 0 with size 1

AFTER:   Particle list is truncated at, 9990
         Particle list is truncated at, 9990      <- two truncations survived
         RESULT ok n=1500 no_crash
```

Independent of #265 (which raises `nmxhep` so the truncation is far rarer) and
of #266. Worth having regardless: any generator that can emit an empty record
would hit this, and #265 reduces the frequency rather than removing the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01915awr3zv25frM1ctMAid6
