### PR TITLE
Fix the macOS wheel build on main, gated behind a fast pre-flight stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-  # Changes to the wheel build itself never reached a PR before, which is how
-  # this workflow drifted away from the (green) macOS setup in test.yml. Run the
-  # cheap pre-flight stage on such PRs so the drift is caught before the merge.
+  # Runs the preflight stage only; the wheel matrix stays push-only.
   pull_request:
     paths:
       - '.github/workflows/build.yml'
@@ -14,9 +12,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Stage 1: seconds, no compilation. Catches a broken Fortran toolchain and a
-  # deployment target that the bundled gfortran runtime cannot satisfy -- the
-  # two things that have taken this workflow down after ~1.5 h of doomed matrix.
+  # Gate for the wheel matrix: no compilation, ~30 s. Fails on an unusable
+  # Fortran toolchain or a deployment target the bundled gfortran runtime does
+  # not satisfy, both of which cibuildwheel only reports an hour in.
   preflight:
     name: preflight ${{ matrix.os }}
     strategy:
@@ -82,21 +80,19 @@ jobs:
           path: ~/.cache/chromo
           key: chromo-cache-v2
 
-  # Stage 2: the real matrix, only once the toolchain is known to be sane.
   wheels:
     needs: [preflight, prepare-cache]
     name: ${{ matrix.py }} ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    # The slowest job in this matrix runs ~85 min. Without a bound a wedged
-    # runner burns the GitHub default of 6 h before reporting anything.
+    # Slowest job is ~85 min; the GitHub default of 6 h is too coarse to
+    # notice a wedged runner.
     timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
-        # macos-15 rather than macos-latest: Homebrew builds the gfortran
-        # runtime for the runner's own OS, so building on macOS 26 would raise
-        # the wheels' minimum supported macOS to 16.0 (= 26). Pin the image to
-        # keep the published support floor at macOS 15.
+        # Pinned, not macos-latest: Homebrew builds the gfortran runtime for
+        # the runner's own OS, so the image release sets the minimum macOS of
+        # the published wheels.
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-15]
         arch: [auto]
         py: [cp39, cp310, cp311, cp312, cp313]
@@ -112,10 +108,8 @@ jobs:
           fetch-depth: 0
 
       - name: Setup gfortran
-        # v1.6.1 symlinked /opt/homebrew/bin/gfortran-13 on every macOS >= 14,
-        # which dangles on the Intel runners (Homebrew prefix /usr/local) and
-        # made meson report "Unknown compiler(s): [['gfortran']]". v1.9.x
-        # derives the prefix with `brew --prefix`.
+        # Keep >= v1.9: earlier releases hardcode the /opt/homebrew prefix and
+        # leave a dangling gfortran symlink on the Intel runners.
         uses: fortran-lang/setup-fortran@v1.9.2
         id: setup-fortran
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,61 @@ on:
   push:
     branches:
       - main
+  # Changes to the wheel build itself never reached a PR before, which is how
+  # this workflow drifted away from the (green) macOS setup in test.yml. Run the
+  # cheap pre-flight stage on such PRs so the drift is caught before the merge.
+  pull_request:
+    paths:
+      - '.github/workflows/build.yml'
+      - 'scripts/ci/**'
   workflow_dispatch:
 
 jobs:
-  prepare-cache:
-    # actions/cache archives are OS-scoped, so populate the cache on every OS
-    # that downstream jobs run on.
+  # Stage 1: seconds, no compilation. Catches a broken Fortran toolchain and a
+  # deployment target that the bundled gfortran runtime cannot satisfy -- the
+  # two things that have taken this workflow down after ~1.5 h of doomed matrix.
+  preflight:
+    name: preflight ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup gfortran
+        uses: fortran-lang/setup-fortran@v1.9.2
+        id: setup-fortran
+        with:
+          compiler: gcc
+          version: 13
+
+      - name: Check Fortran toolchain
+        if: runner.os != 'macOS'
+        run: |
+          command -v "${{ steps.setup-fortran.outputs.fc }}" \
+            || { echo "::error::Fortran compiler not on PATH"; exit 1; }
+          "${{ steps.setup-fortran.outputs.fc }}" --version | head -1
+
+      - name: Check macOS wheel toolchain
+        if: runner.os == 'macOS'
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          EXPECTED_MACOS_TARGET: '15.0'
+        run: bash scripts/ci/macos_wheel_preflight.sh
+
+  prepare-cache:
+    # actions/cache archives are OS-scoped, so populate the cache on every OS
+    # that downstream jobs run on.
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-15]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Restore chromo data cache
         uses: actions/cache@v4
@@ -38,14 +82,22 @@ jobs:
           path: ~/.cache/chromo
           key: chromo-cache-v2
 
+  # Stage 2: the real matrix, only once the toolchain is known to be sane.
   wheels:
-    needs: prepare-cache
+    needs: [preflight, prepare-cache]
     name: ${{ matrix.py }} ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    # The slowest job in this matrix runs ~85 min. Without a bound a wedged
+    # runner burns the GitHub default of 6 h before reporting anything.
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
+        # macos-15 rather than macos-latest: Homebrew builds the gfortran
+        # runtime for the runner's own OS, so building on macOS 26 would raise
+        # the wheels' minimum supported macOS to 16.0 (= 26). Pin the image to
+        # keep the published support floor at macOS 15.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-15]
         arch: [auto]
         py: [cp39, cp310, cp311, cp312, cp313]
     steps:
@@ -59,16 +111,23 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Set macOS deployment target
-        if: runner.os == 'macOS'
-        run: echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
-
       - name: Setup gfortran
-        uses: awvwgk/setup-fortran@v1.6.1
+        # v1.6.1 symlinked /opt/homebrew/bin/gfortran-13 on every macOS >= 14,
+        # which dangles on the Intel runners (Homebrew prefix /usr/local) and
+        # made meson report "Unknown compiler(s): [['gfortran']]". v1.9.x
+        # derives the prefix with `brew --prefix`.
+        uses: fortran-lang/setup-fortran@v1.9.2
         id: setup-fortran
         with:
           compiler: gcc
           version: 13
+
+      - name: Set macOS deployment target from the gfortran runtime
+        if: runner.os == 'macOS'
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          EXPECTED_MACOS_TARGET: '15.0'
+        run: bash scripts/ci/macos_wheel_preflight.sh
 
       - if: ${{ matrix.os != 'macos-15-intel' }}
         uses: ts-graphviz/setup-graphviz@v2
@@ -101,7 +160,7 @@ jobs:
           CHROMO_SKIP_GRAPHVIZ: 1
           CIBW_TEST_COMMAND: 'pytest -n auto -vv -k "not QgsjetIII" {project}/tests'
 
-      - if: ${{ matrix.os == 'macos-latest' }}
+      - if: ${{ matrix.os == 'macos-15' }}
         name: cibuildwheel on macOS
         uses: pypa/cibuildwheel@v3.4.0
         env:
@@ -116,9 +175,10 @@ jobs:
           name: wheel-${{ matrix.py }}-${{ matrix.os }}-${{ matrix.arch }}
 
   sdist:
-    needs: prepare-cache
+    needs: [preflight, prepare-cache]
     name: source package
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Restore chromo data cache
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,10 +132,9 @@ jobs:
           compiler: gcc
           version: 13
 
-      # Same pre-flight the release build runs, so the two cannot drift again.
-      # This job deliberately stays on macos-latest: EXPECTED_MACOS_TARGET makes
-      # it warn as soon as a new runner image would raise the support floor of
-      # the wheels that build.yml publishes from macos-15.
+      # Same script build.yml uses. This job stays on macos-latest, so
+      # EXPECTED_MACOS_TARGET warns when a new image would raise the minimum
+      # macOS of the wheels build.yml publishes from macos-15.
       - name: Check macOS wheel toolchain
         if: runner.os == 'macOS'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: awvwgk/setup-fortran@main
+      - uses: fortran-lang/setup-fortran@v1.9.2
         id: setup-fortran
         with:
           compiler: gcc
@@ -126,27 +126,22 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: awvwgk/setup-fortran@main
+      - uses: fortran-lang/setup-fortran@v1.9.2
         id: setup-fortran
         with:
           compiler: gcc
           version: 13
 
-      # The wheel must target at least the minimum OS of the gfortran
-      # runtime dylibs it bundles (Homebrew builds them for the runner's
-      # OS release), otherwise delocate-wheel rejects it. Deriving the
-      # target from libgfortran itself keeps working when macos-latest
-      # moves to a new image.
-      - name: Set macOS deployment target from the gfortran runtime
+      # Same pre-flight the release build runs, so the two cannot drift again.
+      # This job deliberately stays on macos-latest: EXPECTED_MACOS_TARGET makes
+      # it warn as soon as a new runner image would raise the support floor of
+      # the wheels that build.yml publishes from macos-15.
+      - name: Check macOS wheel toolchain
         if: runner.os == 'macOS'
-        run: |
-          lib=$(${{ steps.setup-fortran.outputs.fc }} --print-file-name=libgfortran.dylib)
-          minos=$(vtool -show-build "$lib" | awk '$1 == "minos" || $1 == "version" {print $2; exit}')
-          if [ -z "$minos" ]; then
-            minos="$(sw_vers -productVersion | cut -d. -f1).0"
-          fi
-          echo "libgfortran at $lib has minimum OS $minos"
-          echo "MACOSX_DEPLOYMENT_TARGET=$minos" >> $GITHUB_ENV
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          EXPECTED_MACOS_TARGET: '15.0'
+        run: bash scripts/ci/macos_wheel_preflight.sh
 
       - if: ${{ matrix.os != 'macos-15-intel' }}
         uses: ts-graphviz/setup-graphviz@v2

--- a/scripts/ci/macos_wheel_preflight.sh
+++ b/scripts/ci/macos_wheel_preflight.sh
@@ -1,34 +1,16 @@
 #!/usr/bin/env bash
 #
-# Fast pre-flight check for the macOS wheel toolchain.
+# Pre-flight check for the macOS wheel toolchain, for use before cibuildwheel.
 #
-# Two failure modes have taken the Build workflow down on main without any PR
-# ever seeing them.  Both are cheap to detect up front, but expensive to hit
-# inside cibuildwheel, where they only surface after the Fortran models have
-# been compiled:
-#
-#   1. gfortran is not usable.  setup-fortran <= v1.8 symlinked
-#      /opt/homebrew/bin/gfortran-<v> into /usr/local/bin unconditionally, so
-#      on the Intel runners (Homebrew prefix /usr/local) the symlink dangles.
-#      meson then fails with "Unknown compiler(s): [['gfortran']]".
-#
-#   2. MACOSX_DEPLOYMENT_TARGET is older than the gfortran runtime dylibs that
-#      delocate bundles into the wheel.  Homebrew builds those for the runner's
-#      own OS release, so any hardcoded target breaks the moment the image moves
-#      (macos-latest -> macOS 26 gives dylibs with a minimum target of 16.0).
-#      delocate-wheel rejects the wheel with
-#      "Library dependencies do not satisfy target MacOS version".
-#
-# On success the deployment target derived from the toolchain itself is written
-# to $GITHUB_ENV, so the wheel job has a single source of truth instead of a
-# hardcoded number that has to be remembered on every image bump.
+# Asserts that gfortran compiles and links, then derives
+# MACOSX_DEPLOYMENT_TARGET from the gfortran runtime dylibs and exports it via
+# $GITHUB_ENV.  Homebrew builds those dylibs for the runner's own OS release, so
+# a target hardcoded below theirs makes delocate-wheel reject the finished wheel.
 #
 # Optional inputs:
 #   FC                        Fortran compiler to probe (default: gfortran).
-#   EXPECTED_MACOS_TARGET     Deployment target the released wheels are meant to
-#                             support.  If the toolchain forces something newer,
-#                             emit a warning so a silently raised support floor
-#                             does not go unnoticed.
+#   EXPECTED_MACOS_TARGET     Minimum macOS the released wheels should support.
+#                             Warns if the toolchain forces something newer.
 
 set -euo pipefail
 
@@ -54,14 +36,12 @@ fi
 if [ ! -x "$fc_path" ]; then
   # A dangling symlink resolves as a path but is not executable.
   fail "'$FC' resolves to $fc_path, which is not executable (dangling symlink?). \
-Homebrew prefix here is $(brew --prefix 2>/dev/null || echo unknown); \
-setup-fortran must derive the prefix rather than hardcode /opt/homebrew."
+Homebrew prefix here is $(brew --prefix 2>/dev/null || echo unknown)."
 fi
 echo "$FC -> $fc_path"
 "$FC" --version | head -1
 
-# Compiling and linking is what meson actually does, so prove it works rather
-# than trusting that the binary exists.
+# meson compiles and links, so probe that, not just the binary's existence.
 probe_dir=$(mktemp -d)
 trap 'rm -rf "$probe_dir"' EXIT
 cat >"$probe_dir/probe.f90" <<'EOF'
@@ -109,8 +89,7 @@ fi
 
 echo "Deployment target required by the toolchain: $required"
 
-# A target that was already pinned lower than the runtime dylibs is exactly the
-# state that makes delocate fail, so say so here instead of an hour from now.
+# delocate would reject the wheel over this an hour from now.
 if [ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ] &&
    [ "$MACOSX_DEPLOYMENT_TARGET" != "$required" ] &&
    [ "$(printf '%s\n%s\n' "$MACOSX_DEPLOYMENT_TARGET" "$required" | sort -V | tail -1)" = "$required" ]; then

--- a/scripts/ci/macos_wheel_preflight.sh
+++ b/scripts/ci/macos_wheel_preflight.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Fast pre-flight check for the macOS wheel toolchain.
+#
+# Two failure modes have taken the Build workflow down on main without any PR
+# ever seeing them.  Both are cheap to detect up front, but expensive to hit
+# inside cibuildwheel, where they only surface after the Fortran models have
+# been compiled:
+#
+#   1. gfortran is not usable.  setup-fortran <= v1.8 symlinked
+#      /opt/homebrew/bin/gfortran-<v> into /usr/local/bin unconditionally, so
+#      on the Intel runners (Homebrew prefix /usr/local) the symlink dangles.
+#      meson then fails with "Unknown compiler(s): [['gfortran']]".
+#
+#   2. MACOSX_DEPLOYMENT_TARGET is older than the gfortran runtime dylibs that
+#      delocate bundles into the wheel.  Homebrew builds those for the runner's
+#      own OS release, so any hardcoded target breaks the moment the image moves
+#      (macos-latest -> macOS 26 gives dylibs with a minimum target of 16.0).
+#      delocate-wheel rejects the wheel with
+#      "Library dependencies do not satisfy target MacOS version".
+#
+# On success the deployment target derived from the toolchain itself is written
+# to $GITHUB_ENV, so the wheel job has a single source of truth instead of a
+# hardcoded number that has to be remembered on every image bump.
+#
+# Optional inputs:
+#   FC                        Fortran compiler to probe (default: gfortran).
+#   EXPECTED_MACOS_TARGET     Deployment target the released wheels are meant to
+#                             support.  If the toolchain forces something newer,
+#                             emit a warning so a silently raised support floor
+#                             does not go unnoticed.
+
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Not macOS ($(uname -s)) -- nothing to check."
+  exit 0
+fi
+
+FC=${FC:-gfortran}
+EXPECTED_MACOS_TARGET=${EXPECTED_MACOS_TARGET:-}
+
+fail() {
+  echo "::error title=macOS wheel pre-flight::$*"
+  exit 1
+}
+
+# --- 1. is the Fortran compiler actually usable? ------------------------------
+
+fc_path=$(command -v "$FC" || true)
+if [ -z "$fc_path" ]; then
+  fail "Fortran compiler '$FC' is not on PATH. Check the setup-fortran step."
+fi
+if [ ! -x "$fc_path" ]; then
+  # A dangling symlink resolves as a path but is not executable.
+  fail "'$FC' resolves to $fc_path, which is not executable (dangling symlink?). \
+Homebrew prefix here is $(brew --prefix 2>/dev/null || echo unknown); \
+setup-fortran must derive the prefix rather than hardcode /opt/homebrew."
+fi
+echo "$FC -> $fc_path"
+"$FC" --version | head -1
+
+# Compiling and linking is what meson actually does, so prove it works rather
+# than trusting that the binary exists.
+probe_dir=$(mktemp -d)
+trap 'rm -rf "$probe_dir"' EXIT
+cat >"$probe_dir/probe.f90" <<'EOF'
+subroutine probe(x)
+  implicit none
+  double precision, intent(inout) :: x
+  x = sqrt(x) + 1.0d0
+end subroutine probe
+EOF
+"$FC" -shared -fPIC -o "$probe_dir/libprobe.dylib" "$probe_dir/probe.f90" \
+  || fail "'$FC' cannot compile and link a trivial Fortran shared library."
+echo "Fortran compile + link OK"
+
+# --- 2. what deployment target do the bundled runtime dylibs require? ---------
+
+# vtool reports the LC_BUILD_VERSION / LC_VERSION_MIN_MACOSX of a Mach-O file.
+minos_of() {
+  local lib=$1
+  vtool -show-build "$lib" 2>/dev/null |
+    awk '$1 == "minos" || $1 == "version" { print $2; exit }'
+}
+
+# Everything delocate copies into <pkg>/.dylibs comes from the gcc keg.
+runtime_libs=(libgfortran.dylib libquadmath.dylib libstdc++.dylib libgcc_s.1.1.dylib)
+
+required=""
+for name in "${runtime_libs[@]}"; do
+  lib=$("$FC" --print-file-name="$name")
+  # --print-file-name echoes the input unchanged when it finds nothing.
+  [ "$lib" != "$name" ] && [ -e "$lib" ] || continue
+  minos=$(minos_of "$lib")
+  [ -n "$minos" ] || continue
+  echo "$name ($lib) has a minimum target of $minos"
+  if [ -z "$required" ] ||
+     [ "$(printf '%s\n%s\n' "$required" "$minos" | sort -V | tail -1)" = "$minos" ]; then
+    required=$minos
+  fi
+done
+
+if [ -z "$required" ]; then
+  required="$(sw_vers -productVersion | cut -d. -f1).0"
+  echo "::warning title=macOS wheel pre-flight::Could not read a minimum target \
+from the gfortran runtime dylibs; falling back to the runner OS ($required)."
+fi
+
+echo "Deployment target required by the toolchain: $required"
+
+# A target that was already pinned lower than the runtime dylibs is exactly the
+# state that makes delocate fail, so say so here instead of an hour from now.
+if [ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ] &&
+   [ "$MACOSX_DEPLOYMENT_TARGET" != "$required" ] &&
+   [ "$(printf '%s\n%s\n' "$MACOSX_DEPLOYMENT_TARGET" "$required" | sort -V | tail -1)" = "$required" ]; then
+  fail "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET is older than the \
+$required required by the gfortran runtime dylibs on this runner; \
+delocate-wheel would reject the wheel."
+fi
+
+if [ -n "$EXPECTED_MACOS_TARGET" ] && [ "$EXPECTED_MACOS_TARGET" != "$required" ]; then
+  echo "::warning title=macOS support floor moved::Wheels built here will \
+require macOS $required, not the expected $EXPECTED_MACOS_TARGET. The runner \
+image probably moved to a newer macOS; pin the runner label or update \
+EXPECTED_MACOS_TARGET deliberately."
+fi
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "MACOSX_DEPLOYMENT_TARGET=$required" >>"$GITHUB_ENV"
+fi


### PR DESCRIPTION
`Build` has never been green on `main` — it only triggers on `push`, so no PR
ever exercised it, and it drifted away from the (green) macOS setup in
`test.yml`. Two independent macOS failures in
[run 31360572063](https://github.com/impy-project/chromo/actions/runs/31360572063):

**`macos-15-intel`:** `setup-fortran@v1.6.1` runs
`ln -fs /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran` for every
macOS ≥ 14, but Homebrew's prefix on Intel *is* `/usr/local`, so the symlink
dangles → `meson.build:1:0: ERROR: Unknown compiler(s): [['gfortran']]`.

**`macos-latest`:** that label is macOS 26 now, so the Homebrew gfortran dylibs
have `minos 16.0` while the workflow hardcoded
`MACOSX_DEPLOYMENT_TARGET=15.0` → `delocate-wheel` rejects the wheel with
`Library dependencies do not satisfy target MacOS version 15.0`.

## Changes

- Pin `fortran-lang/setup-fortran@v1.9.2` in `build.yml` and `test.yml`
  (was `@v1.6.1` / unpinned `@main`). v1.9.x derives the prefix via
  `brew --prefix`.
- Derive `MACOSX_DEPLOYMENT_TARGET` from the dylibs delocate actually bundles,
  in `scripts/ci/macos_wheel_preflight.sh`. Generalises the inline `vtool` step
  `test.yml` already had; both workflows now call it, so they can't drift again.
- Build arm64 release wheels on `macos-15`, not `macos-latest` — raising the
  target to 16.0 would make published wheels require macOS 26. `test.yml` stays
  on `macos-latest` with `EXPECTED_MACOS_TARGET=15.0` so it warns on the next
  image bump.
- `preflight` is its own stage that `wheels` and `sdist` depend on: 4 jobs,
  ~30 s, and it catches both failures above. It also runs on PRs touching
  `build.yml` or `scripts/ci/**`.
- `timeout-minutes` everywhere (150 for wheels; slowest successful job was
  85 min).

CI on this PR: preflight 4/4 in 23–34 s, `cibw macos-15-intel` →
`macosx_15_0_x86_64` and `cibw macos-latest` → `macosx_16_0_arm64`, both
delocated and tested clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014arqpGfDHtJek6cJXF2gd9
