### PR TITLE
Fix EPOS h-A production cross section; guard DPMJET queries above the initialization energy

### DIFF
--- a/src/chromo/models/dpmjetIII.py
+++ b/src/chromo/models/dpmjetIII.py
@@ -106,17 +106,13 @@ class DpmjetIIIRun(MCRun):
 
     Notes
     -----
-    Initialize with the highest energy expected in the simulation: the
-    PHOJET hadron-nucleon interpolation tables built by ``DT_INIT``
-    extend only up to the initialization energy, and requesting higher
-    energies later raises ``ValueError``.
+    Initialize at the highest energy of the simulation: the PHOJET
+    hadron-nucleon tables (``DT_INIT``) end there, and higher-energy
+    requests raise ``ValueError``.
 
-    For precision cross-section tabulation, use a fresh instance per
-    (projectile, energy) point: the Glauber cross sections drift
-    progressively when a single instance cycles through many different
-    kinematics (version 19.3, p + air at 100 GeV: sigma_prod 278 mb on
-    the first query vs ~258 mb after many queries at other kinematics
-    in the same process).
+    For cross-section tabulation use a fresh instance per point: the
+    Glauber sigma drifts over many kinematics switches (19.3, p-air
+    100 GeV: sigma_prod 278 mb on first query, ~258 mb late in a loop).
     """
 
     _name = "DPMJET-III"
@@ -308,22 +304,16 @@ class DpmjetIIIRun(MCRun):
             )
             raise ValueError(msg)
 
-        # The PHOJET hadron-nucleon interpolation tables (filled by
-        # DT_INIT) extend only up to the initialization energy; above
-        # the last node PHO_CSINT log-extrapolates from the last two
-        # nodes (warning only at LPRi > 4).
+        # PHOJET h-N tables end at the init energy; PHO_CSINT
+        # log-extrapolates above it (warning only at LPRi > 4)
         if kin.plab > self._max_plab * (1.0 + 1e-9):
             msg = (
-                f"Requested plab = {kin.plab:.6g} GeV/c exceeds the "
-                f"initialization momentum {self._max_plab:.6g} GeV/c. "
-                "Hadron-nucleon cross sections are tabulated only up to "
-                "the initialization energy and are extrapolated above "
-                "it. Initialize with the highest energy expected in the "
-                "simulation and set lower-energy kinematics afterwards, "
-                "e.g.\n"
-                "    kin = FixedTarget(highest_energy, 'p', 'O16')\n"
-                "    generator = DpmjetIII193(kin)\n"
-                "    generator.kinematics = FixedTarget(lower_energy, ...)"
+                f"plab = {kin.plab:.6g} GeV/c exceeds the initialization "
+                f"momentum {self._max_plab:.6g} GeV/c; cross sections "
+                "are tabulated only up to the initialization energy. "
+                "Initialize at the highest energy of the simulation and "
+                "set lower-energy kinematics afterwards via "
+                "generator.kinematics = ..."
             )
             raise ValueError(msg)
 

--- a/src/chromo/models/dpmjetIII.py
+++ b/src/chromo/models/dpmjetIII.py
@@ -103,6 +103,20 @@ class DpmjetIIIRun(MCRun):
     It should work identically for the new 'dpmjet3' module and the legacy
     dpmjet307. No special constructor is necessary and everything is
     handled by the default constructor of the base class.
+
+    Notes
+    -----
+    Initialize with the highest energy expected in the simulation: the
+    PHOJET hadron-nucleon interpolation tables built by ``DT_INIT``
+    extend only up to the initialization energy, and requesting higher
+    energies later raises ``ValueError``.
+
+    For precision cross-section tabulation, use a fresh instance per
+    (projectile, energy) point: the Glauber cross sections drift
+    progressively when a single instance cycles through many different
+    kinematics (version 19.3, p + air at 100 GeV: sigma_prod 278 mb on
+    the first query vs ~258 mb after many queries at other kinematics
+    in the same process).
     """
 
     _name = "DPMJET-III"
@@ -120,6 +134,7 @@ class DpmjetIIIRun(MCRun):
     _ecm_min = 1 * GeV
     _max_A1 = 0
     _max_A2 = 0
+    _max_plab = 0.0
 
     def __init__(self, evt_kin, *, seed=None):
         import chromo
@@ -274,9 +289,10 @@ class DpmjetIIIRun(MCRun):
                 self._frame = EventFrame.CENTER_OF_MASS
             self._max_A1 = kin.p1.A or 1
             self._max_A2 = kin.p2.A or 1
+            self._max_plab = max(kin.plab, 100.0)
             self._lib.dt_init(
                 -1,
-                max(kin.plab, 100.0),
+                self._max_plab,
                 kin.p1.A or 1,
                 kin.p1.Z or 0,
                 kin.p2.A or 1,
@@ -289,6 +305,25 @@ class DpmjetIIIRun(MCRun):
             msg = (
                 "Maximal initialization mass exceeded "
                 f"{kin.p1.A}/{self._max_A1}, {kin.p2.A}/{self._max_A2}"
+            )
+            raise ValueError(msg)
+
+        # The PHOJET hadron-nucleon interpolation tables (filled by
+        # DT_INIT) extend only up to the initialization energy; above
+        # the last node PHO_CSINT log-extrapolates from the last two
+        # nodes (warning only at LPRi > 4).
+        if kin.plab > self._max_plab * (1.0 + 1e-9):
+            msg = (
+                f"Requested plab = {kin.plab:.6g} GeV/c exceeds the "
+                f"initialization momentum {self._max_plab:.6g} GeV/c. "
+                "Hadron-nucleon cross sections are tabulated only up to "
+                "the initialization energy and are extrapolated above "
+                "it. Initialize with the highest energy expected in the "
+                "simulation and set lower-energy kinematics afterwards, "
+                "e.g.\n"
+                "    kin = FixedTarget(highest_energy, 'p', 'O16')\n"
+                "    generator = DpmjetIII193(kin)\n"
+                "    generator.kinematics = FixedTarget(lower_energy, ...)"
             )
             raise ValueError(msg)
 

--- a/src/chromo/models/epos.py
+++ b/src/chromo/models/epos.py
@@ -240,18 +240,13 @@ class EposLHC(MCRun):
         kin = self.kinematics if kin is None else kin
         total, inel, el, dd, sd, _, qel = self._lib.xsection()
         if (kin.p1.A or 1) > 1 or (kin.p2.A or 1) > 1:
-            # Nuclear projectile and/or target. total/inelastic/elastic
-            # are Glauber-MC values from epocrossc; the sd/dd common-
-            # block values are hadron-proton quantities and do not apply
-            # here. inelastic (ionudi=1) includes all projectile
-            # diffraction and is the sigma CORSIKA transports EPOS with
-            # (CORSIKA 7.8050 corsika.F: NEXINI sets isetcs=3/ionudi=1,
-            # NEXSIG interpolates the epos.inics asect21 table = pre-
-            # tabulated epocrossc sigma_ine). prod excludes the
-            # quasi-elastic part qel (projectile emerges non-excited,
-            # target may break up).
+            # epocrossc sigma; the common-block sd/dd are h-p values,
+            # not reported here. inelastic (ionudi=1, all diffraction
+            # included) is CORSIKA's EPOS transport sigma (CORSIKA
+            # 7.8050 corsika.F: NEXINI/NEXSIG, epos.inics asect21).
+            # qel = non-excited projectile diffraction.
             if qel < 0:
-                # crseaaModel path: qel is not available
+                # crseaaModel path: qel unavailable
                 prod = np.nan
                 qela = np.nan
             else:
@@ -264,9 +259,8 @@ class EposLHC(MCRun):
                 prod=prod,
                 quasielastic=qela,
             )
-        # Hadron-proton: every inelastic channel produces particles
-        # (non-excited projectile diffraction off a proton is elastic
-        # scattering), so prod equals inelastic.
+        # h-p: prod = inelastic (non-excited projectile diffraction
+        # on a proton is elastic scattering)
         return CrossSectionData(
             total=total,
             inelastic=inel,

--- a/src/chromo/models/epos.py
+++ b/src/chromo/models/epos.py
@@ -237,15 +237,41 @@ class EposLHC(MCRun):
         self.kinematics = evt_kin
 
     def _cross_section(self, kin=None, max_info=False):
-        total, inel, el, dd, sd, _ = self._lib.xsection()
+        kin = self.kinematics if kin is None else kin
+        total, inel, el, dd, sd, _, qel = self._lib.xsection()
+        if (kin.p1.A or 1) > 1 or (kin.p2.A or 1) > 1:
+            # Nuclear projectile and/or target. total/inelastic/elastic
+            # are Glauber-MC values from epocrossc; the sd/dd common-
+            # block values are hadron-proton quantities and do not apply
+            # here. inelastic (ionudi=1) includes all projectile
+            # diffraction and is the sigma CORSIKA transports EPOS with
+            # (CORSIKA 7.8050 corsika.F: NEXINI sets isetcs=3/ionudi=1,
+            # NEXSIG interpolates the epos.inics asect21 table = pre-
+            # tabulated epocrossc sigma_ine). prod excludes the
+            # quasi-elastic part qel (projectile emerges non-excited,
+            # target may break up).
+            if qel < 0:
+                # crseaaModel path: qel is not available
+                prod = np.nan
+                qela = np.nan
+            else:
+                prod = inel - qel
+                qela = el + qel
+            return CrossSectionData(
+                total=total,
+                inelastic=inel,
+                elastic=el,
+                prod=prod,
+                quasielastic=qela,
+            )
+        # Hadron-proton: every inelastic channel produces particles
+        # (non-excited projectile diffraction off a proton is elastic
+        # scattering), so prod equals inelastic.
         return CrossSectionData(
             total=total,
             inelastic=inel,
-            prod=total
-            - el
-            - sd
-            - dd,  # TODO: We need to ask Tanguy if this is correct to get sigprod
             elastic=el,
+            prod=inel,
             diffractive_xb=sd / 2,  # this is an approximation
             diffractive_ax=sd / 2,  # this is an approximation
             diffractive_xx=dd,

--- a/src/fortran/epos-lhc-r/sources/epos_interface.f
+++ b/src/fortran/epos-lhc-r/sources/epos_interface.f
@@ -180,17 +180,24 @@ C anfe This is a workaround for nuclear fragments in particle history
 
 c-----------------------------------------------------------------------
       subroutine xsection(xsigtot,xsigine,xsigela,xsigdd,xsigsd
-     &    ,xsloela)
+     &    ,xsloela,xsigqel)
 c-----------------------------------------------------------------------
 c     cross section function
+c
+c     xsigqel = quasi-elastic (non-excited projectile diffraction)
+c     part of xsigine; the production cross section is
+c     xsigine - xsigqel. 0 for hadron-proton (non-excited projectile
+c     diffraction off a proton is elastic scattering); -1 if
+c     unavailable (crseaaModel path).
 c-----------------------------------------------------------------------
 
          implicit none
          include 'epos.inc'
          double precision xsigtot,xsigine,xsigela,xsigdd,xsigsd
-     &                   ,xsloela
+     &                   ,xsloela,xsigqel
+         real sigqelaa
 
-Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela
+Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela,xsigqel
 
          xsigtot   = dble( sigtot   )
          xsigine   = dble( sigine   )
@@ -198,15 +205,19 @@ Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela
          xsigdd    = dble( sigdd    )
          xsigsd    = dble( sigsd    )
          xsloela   = dble( sloela   )
+         xsigqel   = 0d0
 c Nuclear cross section only if needed
          ! xsigtot = 0d0
          ! xsigine = 0d0
          ! xsigela = 0d0
          if(maproj.gt.1.or.matarg.gt.1)then
             if(model.eq.1)then
-               call crseaaEpos(sigtotaa,sigineaa,sigcutaa,sigelaaa)
+               call crseaaeposqel(sigtotaa,sigineaa,sigcutaa,sigelaaa
+     &                           ,sigqelaa)
+               xsigqel = dble( sigqelaa )
             else
                call crseaaModel(sigtotaa,sigineaa,sigcutaa,sigelaaa)
+               xsigqel = -1d0
             endif
             xsigtot = dble( sigtotaa )
             xsigine = dble( sigineaa )
@@ -214,4 +225,63 @@ c Nuclear cross section only if needed
          endif
 
          return
+      end
+
+c-----------------------------------------------------------------------
+      subroutine crseaaeposqel(sigt,sigi,sigc,sige,sigql)
+c-----------------------------------------------------------------------
+c nucleus-nucleus (hadron) cross sections from epocrossc Glauber
+c simulations (air-weighted if the target is air), including the
+c quasi-elastic component
+c  sigt  = sig tot
+c  sigi  = sig inelastic (cut + all projectile diffraction)
+c  sigc  = sig cut
+c  sige  = sig elastic (includes target diffraction)
+c  sigql = quasi-elastic part of sigi: projectile emerges non-excited
+c          (0 if ionudi.ne.1, where it is counted as elastic)
+c The production cross section (projectile destroyed) is sigi - sigql.
+c
+c epogcr separates gqel from the diffractive part only under ionudi=2,
+c so ionudi=2 is used for the duration of the Glauber MC. The
+c gqel/gdd split is pure arithmetic after gprod/gabs/gcoh are formed
+c and draws no random numbers, so sigt/sigi/sigc/sige do not depend
+c on this setting.
+c-----------------------------------------------------------------------
+      include 'epos.inc'
+      niter=20000
+      matarg0=matarg
+      ionudi0=ionudi
+      ionudi=2
+      if(idtargin.eq.0)then
+        sigt=0.
+        sigc=0.
+        sigi=0.
+        sige=0.
+        sigd=0.
+        sigql=0.
+        do k=1,3
+          matarg=int(airanxs(k))
+          call epocrossc(niter,xsigt,xsigi,xsigc,xsige,xsigql,xsigd)
+          sigt=sigt+airwnxs(k)*xsigt
+          sigi=sigi+airwnxs(k)*xsigi
+          sigc=sigc+airwnxs(k)*xsigc
+          sige=sige+airwnxs(k)*xsige
+          sigd=sigd+airwnxs(k)*xsigd
+          sigql=sigql+airwnxs(k)*xsigql
+        enddo
+        matarg=matarg0
+      else
+        call epocrossc(niter,sigt,sigi,sigc,sige,sigql,sigd)
+      endif
+      ionudi=ionudi0
+      if(ionudi.ne.1)then
+        sige=sige+sigql      !add non-excited diffractive projectile to elastic
+        sigi=sigi-sigql      !do not count non-excited diffractive projectile in inelastic
+        sigql=0.             !no quasi-elastic part left in sigi
+        if(maproj+matarg.gt.2)then
+          sigc=sigc+sigd*0.95   !for absorbtion cross section remove 5% of the
+                                !excited projectile diffractive cross section
+                                !which "looks like" non excited (approximation)
+        endif
+      endif
       end

--- a/src/fortran/epos-lhc-r/sources/epos_interface.f
+++ b/src/fortran/epos-lhc-r/sources/epos_interface.f
@@ -183,12 +183,9 @@ c-----------------------------------------------------------------------
      &    ,xsloela,xsigqel)
 c-----------------------------------------------------------------------
 c     cross section function
-c
 c     xsigqel = quasi-elastic (non-excited projectile diffraction)
-c     part of xsigine; the production cross section is
-c     xsigine - xsigqel. 0 for hadron-proton (non-excited projectile
-c     diffraction off a proton is elastic scattering); -1 if
-c     unavailable (crseaaModel path).
+c     part of xsigine; sigma_prod = xsigine - xsigqel.
+c     0 for hadron-proton, -1 if unavailable (crseaaModel path).
 c-----------------------------------------------------------------------
 
          implicit none
@@ -230,22 +227,15 @@ c Nuclear cross section only if needed
 c-----------------------------------------------------------------------
       subroutine crseaaeposqel(sigt,sigi,sigc,sige,sigql)
 c-----------------------------------------------------------------------
-c nucleus-nucleus (hadron) cross sections from epocrossc Glauber
-c simulations (air-weighted if the target is air), including the
-c quasi-elastic component
+c h-A / A-A cross sections from epocrossc (air-weighted for air)
 c  sigt  = sig tot
 c  sigi  = sig inelastic (cut + all projectile diffraction)
 c  sigc  = sig cut
 c  sige  = sig elastic (includes target diffraction)
-c  sigql = quasi-elastic part of sigi: projectile emerges non-excited
-c          (0 if ionudi.ne.1, where it is counted as elastic)
-c The production cross section (projectile destroyed) is sigi - sigql.
-c
-c epogcr separates gqel from the diffractive part only under ionudi=2,
-c so ionudi=2 is used for the duration of the Glauber MC. The
-c gqel/gdd split is pure arithmetic after gprod/gabs/gcoh are formed
-c and draws no random numbers, so sigt/sigi/sigc/sige do not depend
-c on this setting.
+c  sigql = quasi-elastic part of sigi (non-excited projectile);
+c          sigma_prod = sigi - sigql
+c ionudi=2 during the MC: epogcr computes gqel only then; the gqel/gdd
+c split is arithmetic after gprod/gabs/gcoh, which stay unchanged.
 c-----------------------------------------------------------------------
       include 'epos.inc'
       niter=20000

--- a/src/fortran/epos-lhc/sources/epos_interface.f
+++ b/src/fortran/epos-lhc/sources/epos_interface.f
@@ -156,17 +156,24 @@ C anfe This is a workaround for nuclear fragments in particle history
 
 c-----------------------------------------------------------------------
       subroutine xsection(xsigtot,xsigine,xsigela,xsigdd,xsigsd
-     &    ,xsloela)
+     &    ,xsloela,xsigqel)
 c-----------------------------------------------------------------------
 c     cross section function
+c
+c     xsigqel = quasi-elastic (non-excited projectile diffraction)
+c     part of xsigine; the production cross section is
+c     xsigine - xsigqel. 0 for hadron-proton (non-excited projectile
+c     diffraction off a proton is elastic scattering); -1 if
+c     unavailable (crseaaModel path).
 c-----------------------------------------------------------------------
 
          implicit none
          include 'epos.inc'
          double precision xsigtot,xsigine,xsigela,xsigdd,xsigsd
-     &                   ,xsloela
+     &                   ,xsloela,xsigqel
+         real sigqelaa
 
-Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela
+Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela,xsigqel
 
          xsigtot   = dble( sigtot   )
          xsigine   = dble( sigine   )
@@ -174,15 +181,19 @@ Cf2py intent(out) xsigtot,xsigine,xsigela,xsigdd,xsigsd,xsloela
          xsigdd    = dble( sigdd    )
          xsigsd    = dble( sigsd    )
          xsloela   = dble( sloela   )
+         xsigqel   = 0d0
 c Nuclear cross section only if needed
          ! xsigtot = 0d0
          ! xsigine = 0d0
          ! xsigela = 0d0
          if(maproj.gt.1.or.matarg.gt.1)then
             if(model.eq.1)then
-               call crseaaEpos(sigtotaa,sigineaa,sigcutaa,sigelaaa)
+               call crseaaeposqel(sigtotaa,sigineaa,sigcutaa,sigelaaa
+     &                           ,sigqelaa)
+               xsigqel = dble( sigqelaa )
             else
                call crseaaModel(sigtotaa,sigineaa,sigcutaa,sigelaaa)
+               xsigqel = -1d0
             endif
             xsigtot = dble( sigtotaa )
             xsigine = dble( sigineaa )
@@ -190,4 +201,63 @@ c Nuclear cross section only if needed
          endif
 
          return
+      end
+
+c-----------------------------------------------------------------------
+      subroutine crseaaeposqel(sigt,sigi,sigc,sige,sigql)
+c-----------------------------------------------------------------------
+c nucleus-nucleus (hadron) cross sections from epocrossc Glauber
+c simulations (air-weighted if the target is air), including the
+c quasi-elastic component
+c  sigt  = sig tot
+c  sigi  = sig inelastic (cut + all projectile diffraction)
+c  sigc  = sig cut
+c  sige  = sig elastic (includes target diffraction)
+c  sigql = quasi-elastic part of sigi: projectile emerges non-excited
+c          (0 if ionudi.ne.1, where it is counted as elastic)
+c The production cross section (projectile destroyed) is sigi - sigql.
+c
+c epogcr separates gqel from the diffractive part only under ionudi=2,
+c so ionudi=2 is used for the duration of the Glauber MC. The
+c gqel/gdd split is pure arithmetic after gprod/gabs/gcoh are formed
+c and draws no random numbers, so sigt/sigi/sigc/sige do not depend
+c on this setting.
+c-----------------------------------------------------------------------
+      include 'epos.inc'
+      niter=20000
+      matarg0=matarg
+      ionudi0=ionudi
+      ionudi=2
+      if(idtarg.eq.0)then
+        sigt=0.
+        sigc=0.
+        sigi=0.
+        sige=0.
+        sigd=0.
+        sigql=0.
+        do k=1,3
+          matarg=int(airanxs(k))
+          call epocrossc(niter,xsigt,xsigi,xsigc,xsige,xsigql,xsigd)
+          sigt=sigt+airwnxs(k)*xsigt
+          sigi=sigi+airwnxs(k)*xsigi
+          sigc=sigc+airwnxs(k)*xsigc
+          sige=sige+airwnxs(k)*xsige
+          sigd=sigd+airwnxs(k)*xsigd
+          sigql=sigql+airwnxs(k)*xsigql
+        enddo
+        matarg=matarg0
+      else
+        call epocrossc(niter,sigt,sigi,sigc,sige,sigql,sigd)
+      endif
+      ionudi=ionudi0
+      if(ionudi.ne.1)then
+        sige=sige+sigql      !add non-excited diffractive projectile to elastic
+        sigi=sigi-sigql      !do not count non-excited diffractive projectile in inelastic
+        sigql=0.             !no quasi-elastic part left in sigi
+        if(maproj+matarg.gt.2)then
+          sigc=sigc+sigd*0.95   !for absorbtion cross section remove 5% of the
+                                !excited projectile diffractive cross section
+                                !which "looks like" non excited (approximation)
+        endif
+      endif
       end

--- a/src/fortran/epos-lhc/sources/epos_interface.f
+++ b/src/fortran/epos-lhc/sources/epos_interface.f
@@ -159,12 +159,9 @@ c-----------------------------------------------------------------------
      &    ,xsloela,xsigqel)
 c-----------------------------------------------------------------------
 c     cross section function
-c
 c     xsigqel = quasi-elastic (non-excited projectile diffraction)
-c     part of xsigine; the production cross section is
-c     xsigine - xsigqel. 0 for hadron-proton (non-excited projectile
-c     diffraction off a proton is elastic scattering); -1 if
-c     unavailable (crseaaModel path).
+c     part of xsigine; sigma_prod = xsigine - xsigqel.
+c     0 for hadron-proton, -1 if unavailable (crseaaModel path).
 c-----------------------------------------------------------------------
 
          implicit none
@@ -206,22 +203,15 @@ c Nuclear cross section only if needed
 c-----------------------------------------------------------------------
       subroutine crseaaeposqel(sigt,sigi,sigc,sige,sigql)
 c-----------------------------------------------------------------------
-c nucleus-nucleus (hadron) cross sections from epocrossc Glauber
-c simulations (air-weighted if the target is air), including the
-c quasi-elastic component
+c h-A / A-A cross sections from epocrossc (air-weighted for air)
 c  sigt  = sig tot
 c  sigi  = sig inelastic (cut + all projectile diffraction)
 c  sigc  = sig cut
 c  sige  = sig elastic (includes target diffraction)
-c  sigql = quasi-elastic part of sigi: projectile emerges non-excited
-c          (0 if ionudi.ne.1, where it is counted as elastic)
-c The production cross section (projectile destroyed) is sigi - sigql.
-c
-c epogcr separates gqel from the diffractive part only under ionudi=2,
-c so ionudi=2 is used for the duration of the Glauber MC. The
-c gqel/gdd split is pure arithmetic after gprod/gabs/gcoh are formed
-c and draws no random numbers, so sigt/sigi/sigc/sige do not depend
-c on this setting.
+c  sigql = quasi-elastic part of sigi (non-excited projectile);
+c          sigma_prod = sigi - sigql
+c ionudi=2 during the MC: epogcr computes gqel only then; the gqel/gdd
+c split is arithmetic after gprod/gabs/gcoh, which stay unchanged.
 c-----------------------------------------------------------------------
       include 'epos.inc'
       niter=20000

--- a/tests/test_dpmjetIII.py
+++ b/tests/test_dpmjetIII.py
@@ -39,6 +39,26 @@ def run_three_events(p1, model):
         assert len(evt.en) > 0
 
 
+def run_init_energy_guard(model):
+    # DPMJET tabulates hadron-nucleon cross sections in dt_init only up
+    # to the initialization energy; requesting higher-energy kinematics
+    # afterwards must raise instead of silently extrapolating.
+    evt_kin = chromo.kinematics.FixedTarget(1e3, "proton", "O16")
+    m = model(evt_kin, seed=1)
+    # at or below the initialization energy: allowed
+    m.cross_section(chromo.kinematics.FixedTarget(1e2, "proton", "O16"))
+    try:
+        m.cross_section(chromo.kinematics.FixedTarget(1e4, "proton", "O16"))
+    except ValueError:
+        return True
+    return False
+
+
+@pytest.mark.parametrize("model", get_dpmjets())
+def test_init_energy_guard(model):
+    assert run_in_separate_process(run_init_energy_guard, model)
+
+
 def run_cross_section_ntrials(model):
     event_kin = chromo.kinematics.FixedTarget(1e4, "proton", "O16")
     event_generator = model(event_kin)

--- a/tests/test_epos.py
+++ b/tests/test_epos.py
@@ -9,6 +9,7 @@ from particle import literals as lp
 from chromo.constants import GeV
 from chromo.kinematics import CenterOfMass
 from chromo.models import EposLHC
+from chromo.util import naneq
 
 from .util import (
     reference_charge,
@@ -76,6 +77,8 @@ def test_cross_section():
     assert_allclose(c.total, 38.2, atol=0.1)
     assert_allclose(c.inelastic, 30.7, atol=0.1)
     assert_allclose(c.elastic, 7.4, atol=0.1)
+    # for hadron-proton every inelastic channel produces particles
+    assert_allclose(c.prod, c.inelastic)
     assert_allclose(c.diffractive_xb, 1.6, atol=0.1)
     assert_allclose(c.diffractive_ax, 1.6, atol=0.1)
     assert_allclose(c.diffractive_xx, 9.9, atol=0.1)
@@ -84,6 +87,21 @@ def test_cross_section():
         c.non_diffractive,
         c.inelastic - c.diffractive_xb - c.diffractive_ax - c.diffractive_xx,
     )
+
+
+def test_cross_section_hA():
+    c = run_in_separate_process(run_cross_section, "p", "O16")
+    # Glauber-MC (epocrossc) bookkeeping with ionudi=1:
+    # inelastic includes all projectile diffraction; prod excludes its
+    # quasi-elastic (non-excited projectile diffraction) part.
+    assert c.total > c.inelastic > c.prod > 0
+    assert c.quasielastic > c.elastic
+    assert_allclose(c.prod, c.inelastic + c.elastic - c.quasielastic, rtol=1e-6)
+    # the hadron-proton sd/dd values do not apply to h-A
+    naneq(c.diffractive_xb, np.nan)
+    naneq(c.diffractive_ax, np.nan)
+    naneq(c.diffractive_xx, np.nan)
+    naneq(c.diffractive_axb, np.nan)
 
 
 def test_charge(event):


### PR DESCRIPTION
## EPOS (LHC, LHC-R): `CrossSectionData.prod` invalid for h-A

`prod = total - el - sd - dd` (the old `TODO: ask Tanguy`):

- For `maproj>1 or matarg>1`, `xsection()` overwrites `total/inelastic/elastic` with `crseaaEpos` nuclear values, but `sigsd`/`sigdd` keep their h-p values → the formula subtracts h-p diffraction from an h-A total.
- Even for h-p it over-subtracts: excited diffraction produces particles.

Fix:

- New interface routine `crseaaeposqel` (copy of `crseaaEpos`) exports `sigql` = non-excited projectile diffraction (quasi-elastic) from `epocrossc`; `xsection()` returns it as a 7th output.
- `epogcr` computes `gqel` only under `ionudi=2` (identically 0 for `ionudi=1` with `iLHC=1`), so the routine sets `ionudi=2` during the Glauber MC and restores it. The `gqel`/`gdd` split is post-MC arithmetic with no extra RNG draws — `total/inelastic/elastic` verified bit-identical to the previous `ionudi=1` call; event generation unaffected.
- Python: h-A → `prod = inelastic - qel`, `quasielastic = elastic + qel` (same convention as the DPMJET wrapper); h-p sd/dd reported as NaN. h-p → `prod = inelastic` (non-excited projectile diffraction on a proton is elastic).
- `inelastic` (ionudi=1, all diffraction included) is the sigma CORSIKA transports EPOS with — CORSIKA 7.8050 `corsika.F`: `NEXINI` sets `isetcs=3`/`ionudi=1`, `NEXSIG` interpolates the `epos.inics` `asect21` table (pre-tabulated `epocrossc` sigma_ine; the file is byte-identical to chromo's `iamdata/eposlhcr/epos.inics`).
- Also: `matarg` saved/restored around the air loop (upstream `crseaaEpos` leaves it at the last air component).

Numbers (seed 1, fresh process each):

| case | total | inel | el | qel | prod (new) |
|---|---|---|---|---|---|
| LHC pp, 10 GeV cm | 38.25 | 30.77 | 7.48 | — | 30.77 (old: 17.7) |
| LHC p-O16, 100 GeV lab | 405.1 | 287.4 | 117.6 | 19.7 | 267.8 |
| LHC-R p-O16, 100 GeV lab | 387.6 | 285.1 | 102.6 | 46.0 | 239.1 |

## DPMJET (19.1/19.3/3.0-7): silent extrapolation above the init energy

`dt_init` fills the PHOJET h-N interpolation tables only up to the init energy. Above the last node `PHO_CSINT` log-extrapolates from the last two nodes; its warning is gated behind `LPRi>4` (chromo default `lpri=1`). `_set_kinematics` guarded only the masses. Fix: store the init momentum, raise `ValueError` when later kinematics exceed it (mirrors the mass guard).

Documented in the `DpmjetIIIRun` docstring (no code fix): Glauber σ drifts when one instance cycles many kinematics — p-air 100 GeV `prod` ≈ 278 mb on first query vs ≈ 258 mb late in a long loop (19.3, `max_info=True`, 10k trials, seed scatter only ~0.4%). Precision tabulation needs a fresh instance per point.

## Note (no change)

EPOS `eposinecrse`/`pscrse(iqq=4)` is non-monotonic in E for h-air (LHC p-air: 267.9 mb @ 31.6 GeV → 255.2 mb @ 1 TeV → rising). chromo doesn't call it.

## Tests

- `test_epos.py::test_cross_section`: + `prod == inelastic` (pp).
- `test_epos.py::test_cross_section_hA` (new): ordering, `prod = inel + el - quasielastic`, sd/dd NaN.
- `test_dpmjetIII.py::test_init_energy_guard` (new, all versions): below init OK, above raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01915awr3zv25frM1ctMAid6
