### PR TITLE
fix(pythia8): Angantyr — append non-default projectiles to Beams:idAList

### DIFF
--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -792,9 +792,30 @@ class Pythia8Angantyr(MCRun):
         # Pythia 8.317 default (BeamParameters.xml).  The membership
         # check in HISubCollisionModel::init is an exact-id comparison,
         # so e.g. 2112, -2212, 321, 130, -211 are NOT covered.
-        default_ida = [2212, 211, 311, 221, 331, 333, 411, 431,
-                       443, 511, 531, 541, 553, 3212, 3312, 3334,
-                       4112, 4312, 4332, 5112, 5312, 5332]
+        default_ida = [
+            2212,
+            211,
+            311,
+            221,
+            331,
+            333,
+            411,
+            431,
+            443,
+            511,
+            531,
+            541,
+            553,
+            3212,
+            3312,
+            3334,
+            4112,
+            4312,
+            4332,
+            5112,
+            5312,
+            5332,
+        ]
         # NB: PDGID.is_nucleus is True also for p/n, hence
         # is_real_nucleus (A > 1).  The id must be APPENDED:
         # BeamSetup::setBeamIDs hardcodes PDF slot indices matching the

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -10,7 +10,7 @@ from particle import literals as lp
 from chromo.common import CrossSectionData, EventData, MCRun
 from chromo.constants import GeV, standard_projectiles
 from chromo.kinematics import EventFrame
-from chromo.util import Nuclei, _cached_data_dir, name2pdg
+from chromo.util import Nuclei, _cached_data_dir, is_real_nucleus, name2pdg
 
 # Tabulated average number of inelastic hN collisions per hA collision,
 # ported from PythiaCascade.h (Pythia 8.317).  Used by both Cascade and
@@ -781,7 +781,32 @@ class Pythia8Angantyr(MCRun):
                 msg = f"readString({line!r}) failed"
                 raise RuntimeError(msg)
 
-        pythia.readString(f"Beams:idA = {int(kin.p1)}")
+        # The variable-beam machinery (Beams:allowIDAswitch, needed for
+        # live target/energy switching) only supports projectiles from
+        # Beams:idAList; HISubCollisionModel silently substitutes
+        # idAList[0] (= proton) for anything else, which freezes the
+        # hard-process (heavy-flavor) rates at the initialization energy
+        # for beams like n, pbar, K+-, K0L, pi-.  Put the actual
+        # projectile first in the list so it is properly initialized.
+        idA = int(kin.p1)
+        # Pythia 8.317 default (BeamParameters.xml).  The membership
+        # check in HISubCollisionModel::init is an exact-id comparison,
+        # so e.g. 2112, -2212, 321, 130, -211 are NOT covered.
+        default_ida = [2212, 211, 311, 221, 331, 333, 411, 431,
+                       443, 511, 531, 541, 553, 3212, 3312, 3334,
+                       4112, 4312, 4332, 5112, 5312, 5332]
+        # NB: PDGID.is_nucleus is True also for p/n, hence
+        # is_real_nucleus (A > 1).  The id must be APPENDED:
+        # BeamSetup::setBeamIDs hardcodes PDF slot indices matching the
+        # default list order (2212 -> 0, 211 -> 1, ...), so the default
+        # entries must keep their positions.
+        if not is_real_nucleus(kin.p1) and idA not in default_ida:
+            ida_str = ",".join(str(i) for i in default_ida + [idA])
+            if not pythia.readString(f"Beams:idAList = {{{ida_str}}}"):
+                msg = "setting Beams:idAList failed"
+                raise RuntimeError(msg)
+
+        pythia.readString(f"Beams:idA = {idA}")
         pythia.readString(f"Beams:idB = {int(kin.p2)}")
         pythia.readString(f"Beams:eCM = {kin.ecm}")
 

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -781,17 +781,11 @@ class Pythia8Angantyr(MCRun):
                 msg = f"readString({line!r}) failed"
                 raise RuntimeError(msg)
 
-        # The variable-beam machinery (Beams:allowIDAswitch, needed for
-        # live target/energy switching) only supports projectiles from
-        # Beams:idAList; HISubCollisionModel silently substitutes
-        # idAList[0] (= proton) for anything else, which freezes the
-        # hard-process (heavy-flavor) rates at the initialization energy
-        # for beams like n, pbar, K+-, K0L, pi-.  Put the actual
-        # projectile first in the list so it is properly initialized.
+        # Beams:idAList gates the variable-beam machinery; beams outside it
+        # silently run with idAList[0] (proton) hard-process rates. The
+        # Pythia 8.317 default (BeamParameters.xml) uses an exact-id match,
+        # so e.g. 2112, -2212, 321, 130 are not covered.
         idA = int(kin.p1)
-        # Pythia 8.317 default (BeamParameters.xml).  The membership
-        # check in HISubCollisionModel::init is an exact-id comparison,
-        # so e.g. 2112, -2212, 321, 130, -211 are NOT covered.
         default_ida = [
             2212,
             211,
@@ -816,23 +810,15 @@ class Pythia8Angantyr(MCRun):
             5312,
             5332,
         ]
-        # NB: PDGID.is_nucleus is True also for p/n, hence
-        # is_real_nucleus (A > 1).  The id must be APPENDED:
-        # BeamSetup::setBeamIDs hardcodes PDF slot indices matching the
-        # default list order (2212 -> 0, 211 -> 1, ...), so the default
-        # entries must keep their positions.
         if not is_real_nucleus(kin.p1) and idA not in default_ida:
-            ida_str = ",".join(str(i) for i in default_ida + [idA])
+            # Append only: BeamSetup::setBeamIDs maps PDF slots by
+            # default-list position.
+            ida_str = ",".join(str(i) for i in [*default_ida, idA])
             if not pythia.readString(f"Beams:idAList = {{{ida_str}}}"):
                 msg = "setting Beams:idAList failed"
                 raise RuntimeError(msg)
-            # Per-beam initialization tables (generated once with
-            # scripts/generate_angantyr_tables.py, with the target species
-            # appended to Beams:idAList; main424-equivalent)
-            # for species the bundled InitDefault* files do not cover;
-            # without them every init recomputes the MPI/SigFit grids
-            # for this beam (>1 h).  Loaded last so the stored
-            # Init:reuse* grids override the bundled ones.
+            # Per-beam init tables avoid recomputing MPI/SigFit grids at
+            # every init (>1 h). See scripts/generate_angantyr_tables.py.
             beam_table = self._setups_dir / f"InitAngantyr_beam_{idA}.cmnd"
             if beam_table.exists():
                 self._load_cmnd_file(pythia, beam_table)

--- a/src/chromo/models/pythia8.py
+++ b/src/chromo/models/pythia8.py
@@ -805,6 +805,16 @@ class Pythia8Angantyr(MCRun):
             if not pythia.readString(f"Beams:idAList = {{{ida_str}}}"):
                 msg = "setting Beams:idAList failed"
                 raise RuntimeError(msg)
+            # Per-beam initialization tables (generated once with
+            # scripts/generate_angantyr_tables.py, with the target species
+            # appended to Beams:idAList; main424-equivalent)
+            # for species the bundled InitDefault* files do not cover;
+            # without them every init recomputes the MPI/SigFit grids
+            # for this beam (>1 h).  Loaded last so the stored
+            # Init:reuse* grids override the bundled ones.
+            beam_table = self._setups_dir / f"InitAngantyr_beam_{idA}.cmnd"
+            if beam_table.exists():
+                self._load_cmnd_file(pythia, beam_table)
 
         pythia.readString(f"Beams:idA = {idA}")
         pythia.readString(f"Beams:idB = {int(kin.p2)}")


### PR DESCRIPTION
Pythia8's variable-beam machinery (`Beams:allowIDAswitch`, required for live target/energy switching) only supports projectiles from `Beams:idAList`; HISubCollisionModel silently substitutes `idAList[0]` (= proton) for anything else. This froze hard-process (heavy-flavor) rates at the initialization energy for beams like n, pbar, K+-, K0L, pi-.

The fix appends the actual projectile to the idA list at setup (APPENDED, because `BeamSetup::setBeamIDs` hardcodes PDF slot indices for the default entries) and optionally loads per-beam init tables (`InitAngantyr_beam_<id>.cmnd`) so init doesn't recompute MPI/SigFit grids (>1 h) for uncovered species.

Split out of #232. Generated with `scripts/generate_angantyr_tables.py` (main424-equivalent).